### PR TITLE
feat: add configurable dock visibility, workspace, and layout

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -6,6 +6,7 @@ import Quickshell.Wayland
 import Quickshell.Io
 import qs.Commons
 import qs.Ui
+import "DockSettings.js" as DockSettings
 
 BarWidget {
   id: root
@@ -13,7 +14,10 @@ BarWidget {
 
   property string settingsPath: Quickshell.env("HOME") + "/.config/omarchy/dock-settings.json"
   property bool dockEnabled: true
-  property bool autohide: false
+  property string visibilityMode: "always"
+  readonly property bool autohide: root.visibilityMode !== "always"
+  property string spaceMode: "exclusive"
+  property string visibleWorkspace: "all"
   property bool showFolderTitles: true
   property bool showBadges: true
   property bool widgetsEnabled: true
@@ -39,11 +43,12 @@ BarWidget {
       var txt = settingsFile.text()
       if (txt && txt.trim().length > 0) {
         var s = JSON.parse(txt)
+        var normalized = DockSettings.normalize(s)
+        root.visibilityMode = normalized.visibilityMode
+        root.spaceMode = normalized.spaceMode
+        root.visibleWorkspace = normalized.visibleWorkspace
         if (s && s.dockEnabled !== undefined) {
           root.dockEnabled = (s.dockEnabled === true)
-        }
-        if (s && s.autohide !== undefined) {
-          root.autohide = (s.autohide === true)
         }
         if (s && s.showFolderTitles !== undefined) {
           root.showFolderTitles = (s.showFolderTitles === true)
@@ -80,7 +85,10 @@ BarWidget {
     } catch(e) {}
 
     s.dockEnabled = root.dockEnabled
-    s.autohide = root.autohide
+    s.visibilityMode = root.visibilityMode
+    s.autohide = DockSettings.legacyAutohide(root.visibilityMode)
+    s.spaceMode = root.spaceMode
+    s.visibleWorkspace = root.visibleWorkspace
     s.showFolderTitles = root.showFolderTitles
     s.showBadges = root.showBadges
     s.widgetsEnabled = root.widgetsEnabled
@@ -110,9 +118,36 @@ BarWidget {
   }
 
   function setAutohide(val) {
-    root.autohide = val
+    root.visibilityMode = val ? "hover" : "always"
     if (root.bar && typeof root.bar.run === "function") {
       root.bar.run("omarchy-shell rosakodu.dock setAutohide " + (val ? "true" : "false"))
+    } else {
+      saveSettings()
+    }
+  }
+
+  function setVisibilityMode(mode) {
+    root.visibilityMode = DockSettings.normalizeVisibilityMode(mode, false)
+    if (root.bar && typeof root.bar.run === "function") {
+      root.bar.run("omarchy-shell rosakodu.dock setVisibilityMode " + root.visibilityMode)
+    } else {
+      saveSettings()
+    }
+  }
+
+  function setSpaceMode(mode) {
+    root.spaceMode = DockSettings.normalizeSpaceMode(mode)
+    if (root.bar && typeof root.bar.run === "function") {
+      root.bar.run("omarchy-shell rosakodu.dock setSpaceMode " + root.spaceMode)
+    } else {
+      saveSettings()
+    }
+  }
+
+  function setVisibleWorkspace(workspace) {
+    root.visibleWorkspace = DockSettings.normalizeVisibleWorkspace(workspace)
+    if (root.bar && typeof root.bar.run === "function") {
+      root.bar.run("omarchy-shell rosakodu.dock setVisibleWorkspace " + root.visibleWorkspace)
     } else {
       saveSettings()
     }
@@ -290,6 +325,7 @@ BarWidget {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.minimumWidth: 0
               Layout.alignment: Qt.AlignVCenter
               spacing: 2
 
@@ -365,10 +401,12 @@ BarWidget {
 
             ColumnLayout {
               Layout.fillWidth: true
+              Layout.minimumWidth: 0
               Layout.alignment: Qt.AlignVCenter
               spacing: 2
 
               Text {
+                Layout.fillWidth: true
                 text: "Autohide dock"
                 font.family: Style.font.family
                 font.pixelSize: 12
@@ -377,10 +415,15 @@ BarWidget {
               }
 
               Text {
-                text: "Hide dock when not hovered"
+                Layout.fillWidth: true
+                text: root.autohide
+                  ? (root.visibilityMode === "keybind" ? "Shortcut reveal with timed hide" : "Hide dock when not hovered")
+                  : "Keep the dock visible by default"
                 font.family: Style.font.family
                 font.pixelSize: 10
                 color: Color.muted
+                elide: Text.ElideRight
+                maximumLineCount: 1
               }
             }
 
@@ -389,6 +432,8 @@ BarWidget {
               id: switchTrack
               Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
               Layout.preferredWidth: 36
+              Layout.minimumWidth: 36
+              Layout.maximumWidth: 36
               Layout.preferredHeight: 20
               width: 36
               height: 20
@@ -420,7 +465,65 @@ BarWidget {
           }
         }
 
-        // Toggle Folder Names Row
+      Dropdown {
+        Layout.fillWidth: true
+        enabled: root.dockEnabled && root.autohide
+        opacity: enabled ? 1.0 : 0.4
+        label: "Automatic reveal method"
+        value: root.visibilityMode === "keybind" ? "keybind" : "hover"
+        options: [
+          { value: "hover", label: "Screen-edge hover" },
+          { value: "keybind", label: "Keyboard shortcut" }
+        ]
+        onChanged: function(value) { root.setVisibilityMode(value) }
+      }
+
+      Text {
+        Layout.fillWidth: true
+        visible: root.dockEnabled
+        text: "Keyboard toggle (when autohide is off or Keyboard shortcut is selected): omarchy-shell -q rosakodu.dock toggleReveal"
+        wrapMode: Text.WordWrap
+        font.family: Style.font.family
+        font.pixelSize: 9
+        color: Color.muted
+      }
+
+      Dropdown {
+        Layout.fillWidth: true
+        enabled: root.dockEnabled
+        opacity: enabled ? 1.0 : 0.4
+        label: "Show on workspace"
+        value: root.visibleWorkspace
+        options: [
+          { value: "all", label: "All workspaces" },
+          { value: "1", label: "Workspace 1" },
+          { value: "2", label: "Workspace 2" },
+          { value: "3", label: "Workspace 3" },
+          { value: "4", label: "Workspace 4" },
+          { value: "5", label: "Workspace 5" },
+          { value: "6", label: "Workspace 6" },
+          { value: "7", label: "Workspace 7" },
+          { value: "8", label: "Workspace 8" },
+          { value: "9", label: "Workspace 9" },
+          { value: "10", label: "Workspace 10" }
+        ]
+        onChanged: function(value) { root.setVisibleWorkspace(value) }
+      }
+
+      Dropdown {
+        Layout.fillWidth: true
+        enabled: root.dockEnabled
+        opacity: enabled ? 1.0 : 0.4
+        label: "Window layout"
+        value: root.spaceMode
+        options: [
+          { value: "exclusive", label: "Reserve screen space" },
+          { value: "overlay", label: "Overlay tiled windows" }
+        ]
+        onChanged: function(value) { root.setSpaceMode(value) }
+      }
+
+      // Toggle Folder Names Row
         Rectangle {
           id: folderTitlesRow
           Layout.fillWidth: true

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -7,6 +7,7 @@ import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
 import "DockModel.js" as DockModel
+import "DockSettings.js" as DockSettings
 import "components"
 
 Item {
@@ -92,10 +93,7 @@ Item {
         function toggle(): string { root.toggle(); return "ok" }
         function refresh(): string { return root.refresh() }
         function openWidgetPicker(): string {
-            root.opened = true
-            if (widgetPicker) {
-                widgetPicker.opened = true
-            }
+            root.openWidgetPicker()
             return "ok"
         }
         function addWidget(widgetId: string): string { root.addDockWidget(widgetId); return "ok" }
@@ -106,7 +104,11 @@ Item {
         function setWidgetPosition(pos: string): string { root.setWidgetPosition(pos); return "ok" }
         function setEditMode(val: string): string { root.isEditMode = (val === "true" || val === "1"); return "ok" }
         function setDockEnabled(val: string): string { root.dockEnabled = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
-        function setAutohide(val: string): string { root.autohide = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
+        function setAutohide(val: string): string { root.setAutohide(val === "true" || val === "1"); return "ok" }
+        function setVisibilityMode(mode: string): string { root.setVisibilityMode(mode); return "ok" }
+        function setSpaceMode(mode: string): string { root.setSpaceMode(mode); return "ok" }
+        function setVisibleWorkspace(workspace: string): string { root.setVisibleWorkspace(workspace); return "ok" }
+        function toggleReveal(): string { return root.toggleReveal() }
         function setAutohideEdgeDepth(val: string): string { var n = parseInt(val, 10); if (!isNaN(n) && n >= 1 && n <= 64) { root.autohideEdgeDepth = n; root.saveSettings(); } return "ok" }
         function setShowFolderTitles(val: string): string { root.showFolderTitles = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setShowBadges(val: string): string { root.showBadges = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
@@ -115,8 +117,16 @@ Item {
 
     function openWidgetPicker() {
         root.opened = true
+        root.widgetPickerRevealOwned = false
+        root.widgetPickerPreviousVisibilityOverride = root.visibilityOverride
+        if (!root.dockRevealed) {
+            var result = root.toggleReveal("internal")
+            if (result !== "shown") return
+            root.widgetPickerRevealOwned = true
+        }
         if (widgetPicker) {
             widgetPicker.opened = true
+            autohideLeaveTimer.stop()
         }
     }
 
@@ -313,11 +323,22 @@ Item {
         }
     }
 
-    // Autohide Dock & Folder Settings Configuration
+    // Dock visibility, placement, and folder settings
     property string settingsPath: Quickshell.env("HOME") + "/.config/omarchy/dock-settings.json"
     property bool dockEnabled: true
-    property bool autohide: false
+    property string visibilityMode: "always"
+    readonly property bool autohide: root.visibilityMode !== "always"
+    property int visibilityOverride: DockSettings.VISIBILITY_OVERRIDE_FOLLOW
+    property string keyboardTargetWorkspace: ""
+    property string keyboardTargetMonitorName: ""
+    property string baseDockMonitorName: ""
+    property bool widgetPickerRevealOwned: false
+    property int widgetPickerPreviousVisibilityOverride: DockSettings.VISIBILITY_OVERRIDE_FOLLOW
+    property string spaceMode: "exclusive"
+    readonly property bool reservesSpace: root.spaceMode === "exclusive"
+    property string visibleWorkspace: "all"
     property int autohideEdgeDepth: 1  // pixels from screen edge that trigger dock reveal
+    readonly property int effectiveAutohideEdgeDepth: Math.max(4, Math.min(64, root.autohideEdgeDepth))
     property bool showFolderTitles: true
     property bool showBadges: true
     readonly property bool showAppMenu: root.widgetsEnabled && root.dockWidgets && (root.dockWidgets.indexOf("omarchy.apps") !== -1)
@@ -331,9 +352,104 @@ Item {
     property bool isMenuHovered: false
     property bool isWidgetPanelHovered: false
 
+    function workspaceForSelector(selector) {
+        var normalized = DockSettings.normalizeVisibleWorkspace(selector)
+        if (normalized === "all") return null
+        var workspaces = Hyprland.workspaces && Hyprland.workspaces.values ? Hyprland.workspaces.values : []
+        for (var i = 0; i < workspaces.length; i++) {
+            var workspace = workspaces[i]
+            if (workspace && DockSettings.workspaceMatches(normalized, workspace.id, workspace.name)) {
+                return workspace
+            }
+        }
+        return null
+    }
+
+    function screenForMonitorName(monitorName) {
+        var name = String(monitorName || "")
+        if (name === "") return null
+        var screens = Quickshell.screens || []
+        for (var i = 0; i < screens.length; i++) {
+            if (screens[i] && String(screens[i].name || "") === name) return screens[i]
+        }
+        return null
+    }
+
+    function screenForMonitor(monitor) {
+        return monitor ? root.screenForMonitorName(monitor.name) : null
+    }
+
+    function focusedWorkspaceForKeyboardToggle() {
+        var toplevel = Hyprland.activeToplevel
+        if (toplevel && toplevel.workspace) return toplevel.workspace
+        if (Hyprland.focusedWorkspace) return Hyprland.focusedWorkspace
+        if (Hyprland.focusedMonitor && Hyprland.focusedMonitor.activeWorkspace) {
+            return Hyprland.focusedMonitor.activeWorkspace
+        }
+        return null
+    }
+
+    readonly property bool hasExplicitWorkspace: root.visibleWorkspace !== "all"
+    readonly property var configuredWorkspace: root.hasExplicitWorkspace
+        ? root.workspaceForSelector(root.visibleWorkspace)
+        : null
+    readonly property var keyboardTargetWorkspaceObject: root.keyboardTargetWorkspace !== ""
+        ? root.workspaceForSelector(root.keyboardTargetWorkspace)
+        : null
+    readonly property var effectiveDockScreen: {
+        var target = DockSettings.dockScreenTarget(
+            root.visibleWorkspace,
+            root.visibilityMode,
+            root.visibilityOverride
+        )
+        if (target === "configured" && root.configuredWorkspace && root.configuredWorkspace.monitor) {
+            var configuredScreen = root.screenForMonitor(root.configuredWorkspace.monitor)
+            if (configuredScreen) return configuredScreen
+        }
+        if (target === "captured") {
+            var keyboardScreen = root.screenForMonitorName(root.keyboardTargetMonitorName)
+            if (keyboardScreen) return keyboardScreen
+        }
+        if (target === "focused") {
+            var focusedScreen = root.screenForMonitor(Hyprland.focusedMonitor)
+            if (focusedScreen) return focusedScreen
+        }
+        var baseScreen = root.screenForMonitorName(root.baseDockMonitorName)
+        if (baseScreen) return baseScreen
+        return Quickshell.screens && Quickshell.screens.length > 0 ? Quickshell.screens[0] : null
+    }
+
+    readonly property var currentDockWorkspace: {
+        if (root.hasExplicitWorkspace) return root.configuredWorkspace
+        if (root.visibilityOverride === DockSettings.VISIBILITY_OVERRIDE_SHOWN && root.keyboardTargetWorkspaceObject) {
+            return root.keyboardTargetWorkspaceObject
+        }
+        var screen = root.effectiveDockScreen
+        var monitor = screen ? Hyprland.monitorFor(screen) : Hyprland.focusedMonitor
+        if (monitor && monitor.activeWorkspace) return monitor.activeWorkspace
+        return Hyprland.focusedWorkspace
+    }
+
+    readonly property bool workspaceAllowed: {
+        var workspace = root.currentDockWorkspace
+        if (root.hasExplicitWorkspace) return workspace !== null && workspace.active === true
+        if (root.visibilityOverride !== DockSettings.VISIBILITY_OVERRIDE_SHOWN) return true
+        if (!workspace || workspace.active !== true || !workspace.monitor) return false
+        return String(workspace.monitor.name || "") === root.keyboardTargetMonitorName
+    }
+
+    readonly property bool dockAvailable: root.opened
+        && root.pluginEnabled
+        && root.dockEnabled
+        && root.workspaceAllowed
+        && root.isPinnedLoaded
+    readonly property bool dockMapped: root.dockAvailable && !remapTimer.running
+    readonly property bool dockRevealed: root.dockAvailable && !root.shouldSlideOut
+
     property var loadedWidgetItems: []
 
     function checkWidgetPanelsOpen() {
+        if (widgetPicker && widgetPicker.opened) return true
         for (var i = 0; i < root.loadedWidgetItems.length; i++) {
             var w = root.loadedWidgetItems[i]
             if (w) {
@@ -346,8 +462,9 @@ Item {
     }
 
     function evaluateHoverState() {
+        if (!root.autohide) return
         var anyOpenWidget = checkWidgetPanelsOpen()
-        var isDockWinHovered = (!root.autohide || !root.shouldSlideOut) && dockHoverHandler && dockHoverHandler.hovered
+        var isDockWinHovered = !root.shouldSlideOut && dockHoverHandler && dockHoverHandler.hovered
         var anyHover = isDockWinHovered || root.isStackHovered || root.isMenuHovered || root.isWidgetPanelHovered || anyOpenWidget
         if (anyHover) {
             autohideLeaveTimer.stop()
@@ -358,23 +475,9 @@ Item {
     }
 
     function getActiveWorkspaceWindowCount() {
-        var activeId = -1
-        if (Hyprland.focusedWorkspace && Hyprland.focusedWorkspace.id !== undefined) {
-            activeId = Hyprland.focusedWorkspace.id
-        } else if (Hyprland.focusedMonitor && Hyprland.focusedMonitor.activeWorkspace && Hyprland.focusedMonitor.activeWorkspace.id !== undefined) {
-            activeId = Hyprland.focusedMonitor.activeWorkspace.id
-        }
-        if (activeId === -1) return 0
-
-        var wsList = (Hyprland.workspaces && Hyprland.workspaces.values) ? Hyprland.workspaces.values : []
-        for (var i = 0; i < wsList.length; i++) {
-            var ws = wsList[i]
-            if (ws && ws.id === activeId) {
-                if (ws.toplevels && ws.toplevels.values) {
-                    return ws.toplevels.values.length
-                }
-                return 0
-            }
+        var workspace = root.currentDockWorkspace
+        if (workspace && workspace.toplevels && workspace.toplevels.values) {
+            return workspace.toplevels.values.length
         }
         return 0
     }
@@ -404,14 +507,19 @@ Item {
     Timer {
         id: workspaceCheckTimer
         interval: 200
-        running: root.autohide
+        running: root.visibilityMode === "hover" && root.workspaceAllowed
         repeat: true
         onTriggered: root.refreshActiveWorkspaceWindowCount()
     }
 
     readonly property bool isWorkspaceEmpty: root.activeWorkspaceWindowCount === 0
     readonly property bool isDockActive: root.isDockHovered || root.isStackHovered || root.isMenuHovered || root.isWidgetPanelHovered || root.checkWidgetPanelsOpen() || (root.dockDragActiveIndex >= 0)
-    readonly property bool shouldSlideOut: root.autohide && !root.isDockActive && !root.isWorkspaceEmpty
+    readonly property bool shouldSlideOut: DockSettings.shouldSlideOut(
+        root.visibilityMode,
+        root.visibilityOverride,
+        root.isDockActive,
+        root.isWorkspaceEmpty
+    )
 
     function closeAllWidgetPanels() {
         for (var i = 0; i < root.loadedWidgetItems.length; i++) {
@@ -430,14 +538,98 @@ Item {
         }
     }
 
-    onShouldSlideOutChanged: {
-        if (shouldSlideOut) {
-            root.activeStackItem = null
-            root.activeMenuItem = null
-            root.isEditingFolderTitle = false
-            root.isEditMode = false
-            root.closeAllWidgetPanels()
+    function closeDockPopups() {
+        root.activeStackItem = null
+        root.activeMenuItem = null
+        root.isEditingFolderTitle = false
+        root.isEditMode = false
+        if (widgetPicker) widgetPicker.opened = false
+        root.closeAllWidgetPanels()
+    }
+
+    function toggleReveal(revealSource) {
+        if (!root.opened || !root.dockEnabled || !root.pluginEnabled || !root.isPinnedLoaded) return "unavailable"
+        var source = revealSource === "internal" ? "internal" : "keyboard"
+        if (!DockSettings.revealRequestAllowed(root.visibilityMode, source)) return "inactive"
+
+        var focusedWorkspace = root.focusedWorkspaceForKeyboardToggle()
+        var decision = DockSettings.keyboardToggleDecision(
+            root.dockRevealed,
+            root.visibleWorkspace,
+            focusedWorkspace,
+            root.configuredWorkspace
+        )
+
+        if (decision.action === "hide") {
+            autohideLeaveTimer.stop()
+            root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_HIDDEN
+            root.isDockHovered = false
+            root.closeDockPopups()
+            return "hidden"
         }
+        if (decision.action !== "show") return decision.action
+
+        var targetWorkspace = root.hasExplicitWorkspace ? root.configuredWorkspace : focusedWorkspace
+        var targetScreen = targetWorkspace && targetWorkspace.monitor
+            ? root.screenForMonitor(targetWorkspace.monitor)
+            : null
+        if (!targetScreen) return "screen-unavailable"
+
+        root.keyboardTargetWorkspace = decision.targetWorkspace
+        root.keyboardTargetMonitorName = String(targetWorkspace.monitor.name || "")
+        root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_SHOWN
+        if (source === "keyboard" && DockSettings.shouldAutoDismissKeyboardReveal(root.visibilityMode, root.visibilityOverride)) {
+            autohideLeaveTimer.restart()
+        }
+        return "shown"
+    }
+
+    function handleWidgetPickerOpenedChanged(opened) {
+        if (opened) {
+            autohideLeaveTimer.stop()
+            return
+        }
+
+        root.visibilityOverride = DockSettings.releaseInteractionVisibilityOverride(
+            root.widgetPickerRevealOwned,
+            root.widgetPickerPreviousVisibilityOverride,
+            root.visibilityOverride
+        )
+        root.widgetPickerRevealOwned = false
+        root.isDockHovered = false
+        root.evaluateHoverState()
+    }
+
+    onDockRevealedChanged: {
+        if (!dockRevealed) {
+            root.closeDockPopups()
+        }
+    }
+
+    onVisibilityModeChanged: {
+        root.widgetPickerRevealOwned = false
+        root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_FOLLOW
+        root.keyboardTargetWorkspace = ""
+        root.keyboardTargetMonitorName = ""
+        root.isDockHovered = false
+        autohideLeaveTimer.stop()
+    }
+
+    onWorkspaceAllowedChanged: {
+        if (!workspaceAllowed && root.visibilityOverride === DockSettings.VISIBILITY_OVERRIDE_SHOWN) {
+            root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_HIDDEN
+            root.closeDockPopups()
+        }
+    }
+
+    onVisibleWorkspaceChanged: {
+        root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_FOLLOW
+        root.keyboardTargetWorkspace = ""
+        root.keyboardTargetMonitorName = ""
+    }
+
+    onEffectiveDockScreenChanged: {
+        remapTimer.restart()
     }
 
     readonly property var widgetLayout: DockModel.getDockWidgetLayout(root.showAppMenu, root.appMenuPosition, root.widgetsEnabled, root.dockWidgets, root.widgetPosition)
@@ -573,11 +765,12 @@ Item {
             if (txt && txt.trim().length > 0) {
                 var s = JSON.parse(txt)
                 if (!s || typeof s !== "object") return
+                var normalized = DockSettings.normalize(s)
+                root.visibilityMode = normalized.visibilityMode
+                root.spaceMode = normalized.spaceMode
+                root.visibleWorkspace = normalized.visibleWorkspace
                 if (s.dockEnabled !== undefined) {
                     root.dockEnabled = (s.dockEnabled === true)
-                }
-                if (s.autohide !== undefined) {
-                    root.autohide = (s.autohide === true)
                 }
                 if (s.autohideEdgeDepth !== undefined) {
                     var depth = parseInt(s.autohideEdgeDepth, 10)
@@ -619,7 +812,10 @@ Item {
         saveSettingsTimer.restart()
         var jsonStr = JSON.stringify({
             dockEnabled: root.dockEnabled,
-            autohide: root.autohide,
+            visibilityMode: root.visibilityMode,
+            autohide: DockSettings.legacyAutohide(root.visibilityMode),
+            spaceMode: root.spaceMode,
+            visibleWorkspace: root.visibleWorkspace,
             autohideEdgeDepth: root.autohideEdgeDepth,
             showFolderTitles: root.showFolderTitles,
             showBadges: root.showBadges,
@@ -630,6 +826,26 @@ Item {
             widgetSavedPositions: root.widgetSavedPositions || {}
         }, null, 2)
         settingsFile.setText(jsonStr + "\n")
+    }
+
+    function setAutohide(val) {
+        root.visibilityMode = val ? "hover" : "always"
+        saveSettings()
+    }
+
+    function setVisibilityMode(mode) {
+        root.visibilityMode = DockSettings.normalizeVisibilityMode(mode, false)
+        saveSettings()
+    }
+
+    function setSpaceMode(mode) {
+        root.spaceMode = DockSettings.normalizeSpaceMode(mode)
+        saveSettings()
+    }
+
+    function setVisibleWorkspace(workspace) {
+        root.visibleWorkspace = DockSettings.normalizeVisibleWorkspace(workspace)
+        saveSettings()
     }
 
     function setShowAppMenu(val) {
@@ -1337,6 +1553,9 @@ Item {
     }
 
     Component.onCompleted: {
+        if (Hyprland.focusedMonitor) {
+            root.baseDockMonitorName = String(Hyprland.focusedMonitor.name || "")
+        }
         try {
             var scTxt = shellConfigFile.text()
             if (scTxt && scTxt.trim().length > 0) {
@@ -1451,12 +1670,13 @@ Item {
     // 1. The Main Solid Dock Window
     PanelWindow {
         id: dockWindow
-        visible: root.opened && root.pluginEnabled && root.dockEnabled && root.isPinnedLoaded && !remapTimer.running
+        screen: root.effectiveDockScreen
+        visible: root.dockMapped
 
         WlrLayershell.namespace: "omarchy-dock"
         WlrLayershell.layer: WlrLayer.Top
         WlrLayershell.keyboardFocus: root.isEditMode ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
-        exclusionMode: (root.opened && root.pluginEnabled && root.dockEnabled && root.isPinnedLoaded && visible && (!root.autohide || !root.shouldSlideOut)) ? ExclusionMode.Auto : ExclusionMode.Ignore
+        exclusionMode: root.dockRevealed && root.reservesSpace ? ExclusionMode.Auto : ExclusionMode.Ignore
         color: "transparent"
 
         anchors {
@@ -1478,7 +1698,7 @@ Item {
 
         HoverHandler {
             id: dockHoverHandler
-            enabled: !root.autohide || !root.shouldSlideOut
+            enabled: root.autohide && !root.shouldSlideOut
             onHoveredChanged: {
                 root.evaluateHoverState()
             }
@@ -1490,10 +1710,14 @@ Item {
             interval: 1500
             repeat: false
             onTriggered: {
+                if (!root.autohide) return
                 var anyOpenWidget = root.checkWidgetPanelsOpen()
                 var anyHover = (dockHoverHandler && dockHoverHandler.hovered) || root.isStackHovered || root.isMenuHovered || root.isWidgetPanelHovered || anyOpenWidget
                 if (!anyHover) {
                     root.isDockHovered = false
+                    if (DockSettings.shouldAutoDismissKeyboardReveal(root.visibilityMode, root.visibilityOverride)) {
+                        root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_FOLLOW
+                    }
                 }
             }
         }
@@ -1504,7 +1728,7 @@ Item {
             anchors.centerIn: parent
             width: root.isVertical ? (root.slotSize + 4) : Math.max(root.slotSize + 4, root.totalDockDimension + 8)
             height: root.isVertical ? Math.max(root.slotSize + 4, root.totalDockDimension + 8) : (root.slotSize + 4)
-            visible: root.opened && root.pluginEnabled && root.dockEnabled && root.isPinnedLoaded && !remapTimer.running
+            visible: root.dockMapped
             opacity: root.isDockVisualReady ? 1.0 : 0.0
             Behavior on opacity { NumberAnimation { duration: 180; easing.type: Easing.OutCubic } }
             focus: root.isEditMode
@@ -1545,13 +1769,13 @@ Item {
             transform: Translate {
                 id: autohideTranslate
                 x: {
-                    if (!root.autohide || !root.shouldSlideOut) return 0
+                    if (!root.shouldSlideOut) return 0
                     if (root.barPosition === "right") return -56
                     if (root.barPosition === "left") return 56
                     return 0
                 }
                 y: {
-                    if (!root.autohide || !root.shouldSlideOut) return 0
+                    if (!root.shouldSlideOut) return 0
                     if (root.barPosition === "top") return 56
                     if (root.barPosition === "bottom") return -56
                     return 0
@@ -2142,17 +2366,20 @@ Item {
     }
 
     // 5. Autohide Edge Trigger — thin invisible strip at screen edge, activates dock reveal
-    //    Width/height = autohideEdgeDepth px (1–64). Active only when dock is hidden (shouldSlideOut).
+    //    Recreate its input handler after each reveal so stale hover state cannot block re-arming.
     PanelWindow {
         id: edgeTriggerWindow
-        visible: root.opened && root.pluginEnabled && root.dockEnabled && root.isPinnedLoaded
-                 && root.autohide && root.shouldSlideOut
+        screen: dockWindow.screen
+        visible: root.dockAvailable
+                 && root.visibilityMode === "hover"
+                 && root.shouldSlideOut
 
         WlrLayershell.namespace: "omarchy-dock-edge"
         WlrLayershell.layer: WlrLayer.Top
         WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
         exclusionMode: ExclusionMode.Ignore
         color: "transparent"
+        mask: Region { item: edgeTriggerLoader }
 
         // Anchor to the same edge as the dock, no margins — hug the screen edge
         anchors {
@@ -2169,16 +2396,24 @@ Item {
             right: 0
         }
 
-        implicitWidth:  root.isVertical ? root.autohideEdgeDepth : Math.max(root.slotSize + 8, root.totalDockDimension + 14)
-        implicitHeight: root.isVertical ? Math.max(root.slotSize + 8, root.totalDockDimension + 14) : root.autohideEdgeDepth
+        implicitWidth:  root.isVertical ? root.effectiveAutohideEdgeDepth : Math.max(root.slotSize + 8, root.totalDockDimension + 14)
+        implicitHeight: root.isVertical ? Math.max(root.slotSize + 8, root.totalDockDimension + 14) : root.effectiveAutohideEdgeDepth
 
-        HoverHandler {
-            id: edgeTriggerHover
-            onHoveredChanged: {
-                if (hovered) {
-                    // Cursor reached the screen edge — show the dock
-                    root.isDockHovered = true
-                    autohideLeaveTimer.stop()
+        Loader {
+            id: edgeTriggerLoader
+            anchors.fill: parent
+            active: edgeTriggerWindow.visible
+
+            sourceComponent: Component {
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.NoButton
+                    onEntered: {
+                        // Cursor reached the screen edge — show the dock
+                        root.isDockHovered = true
+                        autohideLeaveTimer.restart()
+                    }
                 }
             }
         }

--- a/DockSettings.js
+++ b/DockSettings.js
@@ -1,0 +1,123 @@
+.pragma library
+
+var VISIBILITY_ALWAYS = "always"
+var VISIBILITY_HOVER = "hover"
+var VISIBILITY_KEYBIND = "keybind"
+
+var SPACE_EXCLUSIVE = "exclusive"
+var SPACE_OVERLAY = "overlay"
+
+var VISIBILITY_OVERRIDE_HIDDEN = -1
+var VISIBILITY_OVERRIDE_FOLLOW = 0
+var VISIBILITY_OVERRIDE_SHOWN = 1
+
+function normalizeVisibilityMode(value, legacyAutohide) {
+    var mode = String(value === undefined || value === null ? "" : value).trim().toLowerCase()
+    if (mode === VISIBILITY_ALWAYS || mode === VISIBILITY_HOVER || mode === VISIBILITY_KEYBIND) {
+        return mode
+    }
+    return legacyAutohide === true ? VISIBILITY_HOVER : VISIBILITY_ALWAYS
+}
+
+function normalizeSpaceMode(value) {
+    var mode = String(value === undefined || value === null ? "" : value).trim().toLowerCase()
+    return mode === SPACE_OVERLAY ? SPACE_OVERLAY : SPACE_EXCLUSIVE
+}
+
+function normalizeVisibleWorkspace(value) {
+    if (value === undefined || value === null) return "all"
+    var workspace = String(value).trim()
+    return workspace === "" || workspace.toLowerCase() === "all" ? "all" : workspace
+}
+
+function normalize(raw) {
+    var settings = raw && typeof raw === "object" ? raw : {}
+    return {
+        visibilityMode: normalizeVisibilityMode(settings.visibilityMode, settings.autohide),
+        spaceMode: normalizeSpaceMode(settings.spaceMode),
+        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace)
+    }
+}
+
+function legacyAutohide(visibilityMode) {
+    return normalizeVisibilityMode(visibilityMode, false) !== VISIBILITY_ALWAYS
+}
+
+function workspaceMatches(selector, workspaceId, workspaceName) {
+    var normalized = normalizeVisibleWorkspace(selector)
+    if (normalized === "all") return true
+    return String(workspaceId) === normalized || String(workspaceName) === normalized
+}
+
+function normalizeVisibilityOverride(value) {
+    var override = Number(value)
+    if (override < 0) return VISIBILITY_OVERRIDE_HIDDEN
+    if (override > 0) return VISIBILITY_OVERRIDE_SHOWN
+    return VISIBILITY_OVERRIDE_FOLLOW
+}
+
+function shouldSlideOut(visibilityMode, visibilityOverride, dockActive, workspaceEmpty) {
+    var override = normalizeVisibilityOverride(visibilityOverride)
+    if (override === VISIBILITY_OVERRIDE_HIDDEN) return true
+    if (override === VISIBILITY_OVERRIDE_SHOWN) return false
+
+    var mode = normalizeVisibilityMode(visibilityMode, false)
+    if (mode === VISIBILITY_ALWAYS) return false
+    if (mode === VISIBILITY_KEYBIND) return true
+    return dockActive !== true && workspaceEmpty !== true
+}
+
+function keyboardToggleAllowed(visibilityMode) {
+    return normalizeVisibilityMode(visibilityMode, false) !== VISIBILITY_HOVER
+}
+
+function revealRequestAllowed(visibilityMode, source) {
+    return source === "internal" || keyboardToggleAllowed(visibilityMode)
+}
+
+function shouldAutoDismissKeyboardReveal(visibilityMode, visibilityOverride) {
+    return normalizeVisibilityMode(visibilityMode, false) === VISIBILITY_KEYBIND
+        && normalizeVisibilityOverride(visibilityOverride) === VISIBILITY_OVERRIDE_SHOWN
+}
+
+function releaseInteractionVisibilityOverride(owned, previousOverride, currentOverride) {
+    return owned === true
+        ? normalizeVisibilityOverride(previousOverride)
+        : normalizeVisibilityOverride(currentOverride)
+}
+
+function dockScreenTarget(visibleWorkspace, visibilityMode, visibilityOverride) {
+    if (normalizeVisibleWorkspace(visibleWorkspace) !== "all") return "configured"
+    if (normalizeVisibilityOverride(visibilityOverride) === VISIBILITY_OVERRIDE_SHOWN) return "captured"
+    if (normalizeVisibilityMode(visibilityMode, false) === VISIBILITY_HOVER) return "focused"
+    return "base"
+}
+
+function workspaceIdentity(workspace) {
+    if (!workspace) return ""
+    var name = workspace.name === undefined || workspace.name === null ? "" : String(workspace.name).trim()
+    if (name !== "") return name
+    if (workspace.id === undefined || workspace.id === null) return ""
+    return String(workspace.id)
+}
+
+function keyboardToggleDecision(dockRevealed, configuredSelector, focusedWorkspace, configuredWorkspace) {
+    if (dockRevealed === true) {
+        return { action: "hide", targetWorkspace: "" }
+    }
+
+    var selector = normalizeVisibleWorkspace(configuredSelector)
+    var workspace = selector === "all" ? focusedWorkspace : configuredWorkspace
+    if (!workspace) {
+        return { action: "workspace-unavailable", targetWorkspace: "" }
+    }
+    if (workspace.active !== true) {
+        return { action: "workspace-inactive", targetWorkspace: "" }
+    }
+
+    var identity = workspaceIdentity(workspace)
+    if (identity === "") {
+        return { action: "workspace-unavailable", targetWorkspace: "" }
+    }
+    return { action: "show", targetWorkspace: identity }
+}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ A modern, highly polished, and fully native application dock plugin for **Omarch
 - 🌐 **Full Web Apps (PWA) Support** — Automatic domain matching for Chrome/Chromium web apps (Google Maps, Google Contacts, WhatsApp, YouTube, Discord, etc.) with native GTK theme icons.
 - ⚡ **Zero-Flicker Boot & Tile Lift** — Two-phase initialization instantly reserves Hyprland exclusive space to lift tiled windows smoothly, followed by a monolithic fade-in once all vector theme icons are loaded.
 - 🧭 **Dynamic Auto-Positioning** — Automatically adapts its position opposite to the Omarchy status bar (top $\leftrightarrow$ bottom, left $\leftrightarrow$ right).
-- ⏱️ **Smart Auto-Hide** — Optional auto-hide with a 1.5-second dismissal delay and instant hover reveal.
-- 🎛️ **Status Bar Settings Widget (`BarWidget`)** — Native top bar menu with smooth toggle switches for Dock Enable, Auto-hide, Folder Titles, and Dock Widgets configuration.
+- ⏱️ **Flexible Visibility** — Keep the dock visible, reveal it from the screen edge, or toggle it through a Hyprland keybinding.
+- 🪟 **Exclusive or Overlay Layout** — Reserve space for tiled windows or float the dock above them without changing the workspace layout.
+- 🎛️ **Status Bar Settings Widget (`BarWidget`)** — Native top bar menu for dock visibility, workspace filtering, window layout, folder titles, badges, and dock widgets.
 - 🎨 **100% Native Theme Sync** — Clean borderless status capsules that automatically react to Omarchy colors (`Color.accent`, `Color.bar.background`), system fonts, and window corner radius tokens.
 - 🔤 **Subpixel Vector Glyphs (`DockGlyph`)** — GPU-accelerated vector curve rendering without font hinting distortion or pixel jitter during animations.
 
@@ -62,7 +63,9 @@ You can customize options directly via the `···` status bar widget or in `~/.
 ```json
 {
   "dockEnabled": true,
-  "autohide": false,
+  "visibilityMode": "always",
+  "spaceMode": "exclusive",
+  "visibleWorkspace": "all",
   "showFolderTitles": true,
   "widgetsEnabled": true,
   "widgetPosition": "left",
@@ -71,6 +74,34 @@ You can customize options directly via the `···` status bar widget or in `~/.
   ]
 }
 ```
+
+`visibilityMode` accepts `always`, `hover`, or `keybind`. `spaceMode` accepts
+`exclusive` (reserve screen space) or `overlay` (float above tiled windows).
+`visibleWorkspace` accepts `all`, a numeric workspace ID, or a Hyprland
+workspace name. With `all`, a keyboard opening targets the workspace and
+monitor containing the focused window and keeps that target until the dock is
+closed. With an explicit selector, the dock always targets that workspace and
+can open only while the workspace is active on a monitor.
+
+### Keyboard toggle
+
+Keyboard shortcuts belong to Hyprland, so the plugin never edits your Omarchy
+bindings automatically. To use `SUPER + SHIFT + D`, add this to
+`~/.config/hypr/bindings.lua`:
+
+```lua
+-- Omarchy assigns this shortcut to Docker by default, so replace it explicitly.
+hl.unbind("SUPER + SHIFT + D")
+o.bind("SUPER + SHIFT + D", "Dock", "omarchy-shell -q rosakodu.dock toggleReveal")
+```
+
+Choose any other key combination by changing the first argument to `o.bind`.
+The shortcut works when `visibilityMode` is `always` or `keybind`; `hover`
+accepts only the screen-edge trigger. If the dock is already visible, the first
+press closes it without moving it and the next press opens it on the current
+target. In `keybind` mode the dock starts hidden and automatically hides after
+the same 1.5-second inactivity delay used by hover mode. Keeping the pointer or
+a dock popup active pauses the dismissal timer.
 
 Pinned items and folder layouts are automatically saved to `~/.config/omarchy/dock-pinned.json`.
 
@@ -87,4 +118,3 @@ omarchy plugin remove rosakodu.dock
 ## 📄 License
 
 [MIT](./LICENSE) © 2026 rosakodu
-

--- a/components/FolderMenu.qml
+++ b/components/FolderMenu.qml
@@ -10,19 +10,20 @@ import ".."
 
 PanelWindow {
     id: menuWindow
-    visible: menuWindow.root.isMenuOpen && menuWindow.root.opened && menuWindow.root.pluginEnabled && menuWindow.root.dockEnabled
+    visible: menuWindow.root.isMenuOpen && menuWindow.root.dockRevealed
 
     required property var root
     required property var dockWindow
     property var stackWindow: null
     property alias menuCard: menuCard
+    screen: menuWindow.dockWindow ? menuWindow.dockWindow.screen : null
 
     readonly property bool isDirectDockPopup: !menuWindow.root.isMenuFromFolder
 
     WlrLayershell.namespace: "omarchy-dock-menu"
     WlrLayershell.layer: WlrLayer.Top
     WlrLayershell.keyboardFocus: menuWindow.root.isMenuOpen ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
-    exclusionMode: ExclusionMode.Auto
+    exclusionMode: menuWindow.root.reservesSpace ? ExclusionMode.Auto : ExclusionMode.Ignore
     color: "transparent"
 
     anchors {

--- a/components/FolderPopup.qml
+++ b/components/FolderPopup.qml
@@ -14,15 +14,16 @@ PanelWindow {
     required property var root
     required property var dockWindow
     property alias stackCard: stackCard
+    screen: stackWindow.dockWindow ? stackWindow.dockWindow.screen : null
 
-    visible: stackWindow.root.isStackOpen && stackWindow.root.opened && stackWindow.root.pluginEnabled && stackWindow.root.dockEnabled
+    visible: stackWindow.root.isStackOpen && stackWindow.root.dockRevealed
 
         WlrLayershell.namespace: "omarchy-dock-stack"
         WlrLayershell.layer: WlrLayer.Top
         WlrLayershell.keyboardFocus: stackWindow.root.isEditingFolderTitle
             ? WlrKeyboardFocus.Exclusive
             : (stackWindow.root.isStackOpen ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None)
-        exclusionMode: ExclusionMode.Auto
+    exclusionMode: stackWindow.root.reservesSpace ? ExclusionMode.Auto : ExclusionMode.Ignore
         color: "transparent"
 
         anchors {
@@ -823,4 +824,3 @@ PanelWindow {
                 }
             }
         }
-

--- a/components/WidgetPickerPopup.qml
+++ b/components/WidgetPickerPopup.qml
@@ -17,6 +17,12 @@ PanelWindow {
     property var shell: null
     property bool opened: false
 
+    onOpenedChanged: {
+        if (pickerWindow.root && typeof pickerWindow.root.handleWidgetPickerOpenedChanged === "function") {
+            pickerWindow.root.handleWidgetPickerOpenedChanged(opened)
+        }
+    }
+
     WlrLayershell.namespace: "omarchy-menu"
     WlrLayershell.layer: WlrLayer.Overlay
     WlrLayershell.keyboardFocus: pickerWindow.opened ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
@@ -24,7 +30,7 @@ PanelWindow {
     color: "transparent"
     screen: (pickerWindow.dockWindow && pickerWindow.dockWindow.screen) ? pickerWindow.dockWindow.screen : (Quickshell.screens && Quickshell.screens.length > 0 ? Quickshell.screens[0] : null)
 
-    visible: opened
+    visible: opened && pickerWindow.root && pickerWindow.root.dockRevealed
 
     anchors {
         top: true

--- a/tests/tst_DockSettings.qml
+++ b/tests/tst_DockSettings.qml
@@ -1,0 +1,186 @@
+import QtQuick
+import QtTest
+import "../DockSettings.js" as DockSettings
+
+TestCase {
+    name: "DockSettings"
+
+    function test_defaultsPreserveCurrentBehavior() {
+        var settings = DockSettings.normalize({})
+        compare(settings.visibilityMode, "always")
+        compare(settings.spaceMode, "exclusive")
+        compare(settings.visibleWorkspace, "all")
+    }
+
+    function test_legacyAutohideMigration_data() {
+        return [
+            { tag: "disabled", autohide: false, expected: "always" },
+            { tag: "enabled", autohide: true, expected: "hover" }
+        ]
+    }
+
+    function test_legacyAutohideMigration(data) {
+        compare(DockSettings.normalize({ autohide: data.autohide }).visibilityMode, data.expected)
+    }
+
+    function test_explicitVisibilityModeWinsOverLegacyValue() {
+        compare(DockSettings.normalize({ visibilityMode: "keybind", autohide: false }).visibilityMode, "keybind")
+    }
+
+    function test_invalidEnumsFallBackSafely() {
+        var settings = DockSettings.normalize({
+            visibilityMode: "invalid",
+            autohide: true,
+            spaceMode: "invalid"
+        })
+        compare(settings.visibilityMode, "hover")
+        compare(settings.spaceMode, "exclusive")
+    }
+
+    function test_workspaceNormalization_data() {
+        return [
+            { tag: "missing", input: undefined, expected: "all" },
+            { tag: "empty", input: "  ", expected: "all" },
+            { tag: "all-case", input: "ALL", expected: "all" },
+            { tag: "numeric", input: 3, expected: "3" },
+            { tag: "named", input: " special:scratch ", expected: "special:scratch" }
+        ]
+    }
+
+    function test_workspaceNormalization(data) {
+        compare(DockSettings.normalizeVisibleWorkspace(data.input), data.expected)
+    }
+
+    function test_legacyAutohideSerialization_data() {
+        return [
+            { tag: "always", mode: "always", expected: false },
+            { tag: "hover", mode: "hover", expected: true },
+            { tag: "keybind", mode: "keybind", expected: true }
+        ]
+    }
+
+    function test_legacyAutohideSerialization(data) {
+        compare(DockSettings.legacyAutohide(data.mode), data.expected)
+    }
+
+    function test_workspaceMatching() {
+        verify(DockSettings.workspaceMatches("all", 1, "1"))
+        verify(DockSettings.workspaceMatches("2", 2, "2"))
+        verify(DockSettings.workspaceMatches("special:scratch", -99, "special:scratch"))
+        verify(!DockSettings.workspaceMatches("3", 2, "2"))
+    }
+
+    function test_visibilityState_data() {
+        return [
+            { tag: "always-follow", mode: "always", override: 0, active: false, empty: false, hidden: false },
+            { tag: "always-keybind-hidden", mode: "always", override: -1, active: false, empty: false, hidden: true },
+            { tag: "always-keybind-shown", mode: "always", override: 1, active: false, empty: false, hidden: false },
+            { tag: "hover-active", mode: "hover", override: 0, active: true, empty: false, hidden: false },
+            { tag: "hover-inactive", mode: "hover", override: 0, active: false, empty: false, hidden: true },
+            { tag: "hover-empty", mode: "hover", override: 0, active: false, empty: true, hidden: false },
+            { tag: "hover-keybind-hidden", mode: "hover", override: -1, active: true, empty: true, hidden: true },
+            { tag: "hover-keybind-shown", mode: "hover", override: 1, active: false, empty: false, hidden: false },
+            { tag: "keybind-follow", mode: "keybind", override: 0, active: true, empty: true, hidden: true },
+            { tag: "keybind-shown", mode: "keybind", override: 1, active: false, empty: false, hidden: false }
+        ]
+    }
+
+    function test_visibilityState(data) {
+        compare(DockSettings.shouldSlideOut(data.mode, data.override, data.active, data.empty), data.hidden)
+    }
+
+    function test_keyboardToggleAvailability_data() {
+        return [
+            { tag: "autohide-disabled", mode: "always", expected: true },
+            { tag: "screen-edge-hover", mode: "hover", expected: false },
+            { tag: "keyboard-shortcut", mode: "keybind", expected: true }
+        ]
+    }
+
+    function test_keyboardToggleAvailability(data) {
+        compare(DockSettings.keyboardToggleAllowed(data.mode), data.expected)
+    }
+
+    function test_revealRequestAvailability() {
+        verify(!DockSettings.revealRequestAllowed("hover", "keyboard"))
+        verify(DockSettings.revealRequestAllowed("hover", "internal"))
+        verify(DockSettings.revealRequestAllowed("keybind", "keyboard"))
+        verify(DockSettings.revealRequestAllowed("always", "keyboard"))
+    }
+
+    function test_keyboardAutoDismiss_data() {
+        return [
+            { tag: "always-shown", mode: "always", override: 1, expected: false },
+            { tag: "hover-shown", mode: "hover", override: 1, expected: false },
+            { tag: "keybind-follow", mode: "keybind", override: 0, expected: false },
+            { tag: "keybind-shown", mode: "keybind", override: 1, expected: true }
+        ]
+    }
+
+    function test_keyboardAutoDismiss(data) {
+        compare(DockSettings.shouldAutoDismissKeyboardReveal(data.mode, data.override), data.expected)
+    }
+
+    function test_interactionRevealRelease() {
+        compare(DockSettings.releaseInteractionVisibilityOverride(true, 0, 1), 0)
+        compare(DockSettings.releaseInteractionVisibilityOverride(true, -1, 1), -1)
+        compare(DockSettings.releaseInteractionVisibilityOverride(false, 0, 1), 1)
+        compare(DockSettings.releaseInteractionVisibilityOverride(false, 0, -1), -1)
+    }
+
+    function test_dockScreenTarget_data() {
+        return [
+            { tag: "explicit-workspace", workspace: "7", mode: "hover", override: 0, expected: "configured" },
+            { tag: "internal-capture", workspace: "all", mode: "hover", override: 1, expected: "captured" },
+            { tag: "hover-all", workspace: "all", mode: "hover", override: 0, expected: "focused" },
+            { tag: "hover-all-hidden", workspace: "all", mode: "hover", override: -1, expected: "focused" },
+            { tag: "keybind-follow", workspace: "all", mode: "keybind", override: 0, expected: "base" },
+            { tag: "always-follow", workspace: "all", mode: "always", override: 0, expected: "base" }
+        ]
+    }
+
+    function test_dockScreenTarget(data) {
+        compare(DockSettings.dockScreenTarget(data.workspace, data.mode, data.override), data.expected)
+    }
+
+    function test_visibleDockClosesWithoutRetargeting() {
+        var focusedWorkspace = { id: 2, name: "2", active: true }
+        var decision = DockSettings.keyboardToggleDecision(true, "all", focusedWorkspace, null)
+
+        compare(decision.action, "hide")
+        compare(decision.targetWorkspace, "")
+    }
+
+    function test_hiddenDockCapturesFocusedWorkspaceForAll() {
+        var focusedWorkspace = { id: 3, name: "3", active: true }
+        var decision = DockSettings.keyboardToggleDecision(false, "all", focusedWorkspace, null)
+
+        compare(decision.action, "show")
+        compare(decision.targetWorkspace, "3")
+    }
+
+    function test_explicitWorkspaceDoesNotFollowFocus() {
+        var focusedWorkspace = { id: 3, name: "3", active: true }
+        var configuredWorkspace = { id: 7, name: "7", active: true }
+        var decision = DockSettings.keyboardToggleDecision(false, "7", focusedWorkspace, configuredWorkspace)
+
+        compare(decision.action, "show")
+        compare(decision.targetWorkspace, "7")
+    }
+
+    function test_inactiveExplicitWorkspaceDoesNotOpen() {
+        var focusedWorkspace = { id: 3, name: "3", active: true }
+        var configuredWorkspace = { id: 7, name: "7", active: false }
+        var decision = DockSettings.keyboardToggleDecision(false, "7", focusedWorkspace, configuredWorkspace)
+
+        compare(decision.action, "workspace-inactive")
+        compare(decision.targetWorkspace, "")
+    }
+
+    function test_missingWorkspaceDoesNotOpen() {
+        var decision = DockSettings.keyboardToggleDecision(false, "all", null, null)
+
+        compare(decision.action, "workspace-unavailable")
+        compare(decision.targetWorkspace, "")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `always`, screen-edge `hover`, and `keybind` visibility modes.
- Allow the dock to target all workspaces, a numeric workspace ID, or a named Hyprland workspace.
- Make `all` follow the focused workspace and monitor while preserving fixed-workspace targeting.
- Add `exclusive` and `overlay` layout modes.
- Expose the new options through the native bar settings widget.
- Preserve compatibility with the legacy `autohide` setting.
- Keep widget picker and folder popups on the dock's target screen.
- Harden repeated edge-hover activation and keyboard auto-dismiss behavior.

## Backward compatibility

- Existing configurations without the new fields keep the current defaults:
  - visibility: `always`
  - layout: `exclusive`
  - workspace: `all`
- The legacy `autohide` boolean is still read and serialized.
- The plugin does not modify Hyprland keybindings automatically.

## Testing

- `46` QML tests passed with Qt 6.
- `qmllint` passed for all modified QML files.
- `omarchy plugin validate .` passed.
- `git diff --check main...HEAD` passed.
- Manually verified:
  - repeated screen-edge hover activation;
  - keyboard show/hide and timed dismissal;
  - focused-workspace targeting with `all`;
  - fixed-workspace targeting;
  - exclusive and overlay layouts;
  - widget picker and dock popup behavior.

<img width="288" height="613" alt="image" src="https://github.com/user-attachments/assets/129f088f-ecbf-4e3b-9746-9feb3d994c63" />

<img width="298" height="616" alt="image" src="https://github.com/user-attachments/assets/58683694-4ec3-4d87-8c30-432c8ad81376" />

<img width="271" height="121" alt="image" src="https://github.com/user-attachments/assets/4c538342-686f-4ea9-b762-4f5ccb6f8058" />

<img width="600" height="175" alt="image" src="https://github.com/user-attachments/assets/c7607c5d-8721-455d-aad9-ab4909ef531d" />
