### PR TITLE
fix(badge): let the click that clears a badge still focus the window

### DIFF
--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -1849,8 +1849,17 @@ Item {
         onBadgeChanged: root.doUpdateDockItems()
     }
 
+    // Clearing a badge rebuilds dockItems, and the Repeater below then destroys
+    // the very delegate whose click is still running. Every statement after the
+    // call — the rest of onItemLeftClicked, and DockItem's own handler, which
+    // has not yet asked for the window — would execute in a dead context and
+    // throw "root is not defined", swallowing the click. Defer the clear so the
+    // click finishes before the delegates are replaced.
     function clearBadge(itemData) {
-        if (notifTracker) notifTracker.clearBadge(itemData)
+        if (!notifTracker) return
+        Qt.callLater(function() {
+            if (notifTracker) notifTracker.clearBadge(itemData)
+        })
     }
 
     function getMinimizedToplevels() {


### PR DESCRIPTION
## The symptom

Left-clicking a dock icon that carries a notification badge clears the badge and does nothing else — the window is not focused, and no window is cycled to. The next click, with no badge left to clear, behaves normally. In daily use it reads as "I have to click Slack twice", and on an app with several windows as "clicking does not cycle through them".

## The cause

`onItemLeftClicked` (DockPanel.qml) clears the badge as its first statement, before `DockItem`'s own handler has emitted `restoreOrLaunchRequested`:

```qml
onItemLeftClicked: function(item) {
    if (item && !item.isStack) {
        root.clearBadge(item)      // <- rebuilds dockItems
    }
    ...
    root.activeStackItem = null    // <- DockPanel.qml:2923, dead context
```

Clearing the badge rebuilds `root.dockItems`, the `Repeater` replaces its delegates, and the `DockItem` whose click is still on the stack is destroyed mid-handler. Everything after that line runs in a dead QML context.

Instrumented run, one click on a badged icon:

```
DBGLEFT enter
DBGLEFT after-clearBadge
DBGTHROW ReferenceError: root is not defined @ DockPanel.qml:2923
```

and no invocation of `scripts/dock-minimize.py` at all. The next click on the same icon:

```
DBGLEFT enter
DBGLEFT after-clearBadge
DBGLEFT after-activeStackItem
DBGLEFT after-activeMenuItem
DBGRESTORE targetIndex=0 tops=2 isActive=false
-> activate-instance firefox --index=0
```

Same trace reproduced on Slack (`tops: 1`) and Firefox (`tops: 2`). The warning is visible without instrumentation too, as `WARN scene: DockPanel.qml[2923:-1]: TypeError: Value is undefined and could not be converted to an object`, once per badged click.

## The fix

Defer the clear onto the event loop, in `clearBadge` itself so both call sites are covered — `FolderPopup.qml:794` clears the badge from the same position in its own click handler and has the same hazard. Nothing depends on the clear being synchronous.

## Verification

Omarchy 4.0.2, Hyprland 0.56.2, plugin at `bcf050b`. Before: click on a badged Slack/Firefox icon clears the badge and leaves focus where it was, every time. After: the badge clears and the window is focused on the first click, and repeated clicks cycle through the app's windows as documented.

Note for anyone reproducing this: `Local plugin changed, reloading` does not actually re-read plugin QML — `omarchy restart shell` is needed for a code change to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)