### PR TITLE
fix(keyboard): restore the documented toggle and keybind auto-hide

### DIFF
--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -670,7 +670,7 @@ Item {
     function toggleReveal(revealSource) {
         if (!root.opened || !root.dockEnabled || !root.pluginEnabled || !root.isPinnedLoaded) return "unavailable"
         var source = revealSource === "internal" ? "internal" : "keyboard"
-        if (!DockSettings.revealRequestAllowed(root.visibilityMode, source, root.autohide)) return "inactive"
+        if (!DockSettings.revealRequestAllowed(root.visibilityMode, source)) return "inactive"
 
         var now = Date.now()
         if (now - root.lastToggleRevealTime < 300) {

--- a/DockSettings.js
+++ b/DockSettings.js
@@ -68,18 +68,24 @@ function shouldSlideOut(visibilityMode, visibilityOverride, dockActive, workspac
     return dockActive !== true && workspaceEmpty !== true
 }
 
-function keyboardToggleAllowed(visibilityMode, autohide) {
-    if (autohide !== undefined && autohide !== true) return false
-    return normalizeVisibilityMode(visibilityMode, false) === VISIBILITY_KEYBIND
+// Whether the keyboard shortcut may toggle the dock. Everything but "hover"
+// accepts it; "hover" is the screen-edge trigger's alone, because a dock that
+// reveals on approach has nothing for a keypress to add and the two would fight
+// over visibilityOverride.
+function keyboardToggleAllowed(visibilityMode) {
+    return normalizeVisibilityMode(visibilityMode, false) !== VISIBILITY_HOVER
 }
 
-function revealRequestAllowed(visibilityMode, source, autohide) {
-    if (source === "internal") return true
-    return keyboardToggleAllowed(visibilityMode, autohide)
+function revealRequestAllowed(visibilityMode, source) {
+    return source === "internal" || keyboardToggleAllowed(visibilityMode)
 }
 
+// In "keybind" mode a dock summoned by the shortcut hides itself again once the
+// inactivity timer runs out, the same way hover mode does. A dock the user
+// asked to keep on screen in any other mode stays put.
 function shouldAutoDismissKeyboardReveal(visibilityMode, visibilityOverride) {
-    return false
+    return normalizeVisibilityMode(visibilityMode, false) === VISIBILITY_KEYBIND
+        && normalizeVisibilityOverride(visibilityOverride) === VISIBILITY_OVERRIDE_SHOWN
 }
 
 function releaseInteractionVisibilityOverride(owned, previousOverride, currentOverride) {


### PR DESCRIPTION
Three tests in `tests/tst_DockSettings.qml` fail on `main` (`a469e28`):

```
FAIL!  : DockSettings::test_keyboardToggleAvailability(autohide-disabled)
FAIL!  : DockSettings::test_revealRequestAvailability()
FAIL!  : DockSettings::test_keyboardAutoDismiss(keybind-shown)
```

They have failed since `723cb14`, and as far as I can tell they are right — the README documents exactly what they assert, and that commit changed the implementation without touching either the tests or the docs.

### What is broken

**`keyboardToggleAllowed()`** gained an `autohide` guard and narrowed to `keybind` only:

```js
if (autohide !== undefined && autohide !== true) return false
return normalizeVisibilityMode(visibilityMode, false) === VISIBILITY_KEYBIND
```

`DockPanel.qml` passes `root.autohide`, which is `visibilityMode !== "always"`, so the guard fires in `always` mode and `toggleReveal()` returns `"inactive"`. `SUPER + SHIFT + D` is dead there. The README says:

> The shortcut works when `visibilityMode` is `always` or `keybind`; `hover` accepts only the screen-edge trigger.

Verified on a live session with `visibilityMode: "always"`:

```
$ omarchy-shell rosakodu.dock toggleReveal     # on a469e28
inactive
$ omarchy-shell rosakodu.dock toggleReveal     # with this PR
shown
$ omarchy-shell rosakodu.dock toggleReveal
hidden
```

**`shouldAutoDismissKeyboardReveal()`** was reduced to `return false` while staying wired into the 1500ms inactivity timer it exists for (`DockPanel.qml`), so a dock summoned in `keybind` mode never hides itself again. The README describes that auto-hide, timer pause on hover included:

> In `keybind` mode the dock starts hidden and automatically hides after the same 1.5-second inactivity delay used by hover mode.

### What this PR does

Restores both functions to the documented contract and drops the `autohide` parameter that threaded the reverted guard through `revealRequestAllowed()`. No test changes — the existing ones go green (60 passed, 0 failed).

### If the narrowing was intentional

Then the fix belongs on the other side and I am happy to redo it that way: the three tests and both README paragraphs would need updating instead, and the dead `shouldAutoDismissKeyboardReveal()` call in the inactivity timer should come out. I went with restoring the behaviour because the docs, the tests and the timer wiring all still describe it, and I could not find an issue or PR saying otherwise — but you know the intent and I do not.