### PR TITLE
fix(minimize): aim by address without hiding the app's other windows

### DIFF
--- a/scripts/dock-minimize.py
+++ b/scripts/dock-minimize.py
@@ -231,6 +231,67 @@ def find_desktop_file(desktop_id):
             return clean
     return ""
 
+def split_queries(queries):
+    """Separate the app identifiers from the window selector.
+
+    A dock click sends the app's identifiers (app id, desktop id, exec) and,
+    optionally, which of that app's windows to act on: a Hyprland address
+    ("0x..."), or the legacy "--index=N" / bare-N position. A selector picks a
+    window out of the app's windows -- it must not narrow the match itself, or
+    the app's other windows stop existing as far as the caller can tell, and
+    logic like "focus a sibling after minimizing" has nothing left to find.
+
+    Only a "0x" prefix counts as an address. Hyprland always writes them that
+    way, and app identifiers that happen to be spelled out of hex digits
+    ("deface") are identifiers.
+    """
+    target_index = -1
+    target_addr = ""
+    identifiers = []
+    for q in queries:
+        if q.startswith("--index="):
+            try:
+                target_index = int(q.split("=")[1])
+            except Exception:
+                pass
+        elif q.isdigit() and target_index == -1:
+            try:
+                target_index = int(q)
+            except Exception:
+                pass
+        elif q.lower().startswith("0x") and not target_addr:
+            target_addr = q.lower()
+        else:
+            identifiers.append(q)
+    return identifiers, target_index, target_addr
+
+
+def pick_target(matching, visible_windows, minimized_windows, target_addr, target_index, active_addr):
+    """The one window a dock click is aimed at, out of the app's windows.
+
+    An address names a specific window and wins outright; an index is the
+    legacy form of the same thing and is resolved against Hyprland's client
+    order, which reorders on its own. With neither -- or with a selector whose
+    window is gone -- fall back to the active window (when the caller cares),
+    then the first visible one, then a minimized one.
+    """
+    if target_addr:
+        for c in matching:
+            if str(c.get("address", "")).lower() == target_addr:
+                return c
+    if 0 <= target_index < len(matching):
+        return matching[target_index]
+    if active_addr:
+        for c in matching:
+            if str(c.get("address", "")).lower() == active_addr:
+                return c
+    if visible_windows:
+        return visible_windows[0]
+    if minimized_windows:
+        return minimized_windows[0]
+    return matching[0] if matching else None
+
+
 def launch_fallback(queries):
     # 0. Dedicated native Wayland App-ID launch for cliamp / CLI audio player
     for q in queries:
@@ -322,26 +383,10 @@ def main():
         print(json.dumps(detected_apps))
         return
 
-    target_index = -1
-    filtered_queries = []
-    for q in queries:
-        if q.startswith("--index="):
-            try:
-                target_index = int(q.split("=")[1])
-            except Exception:
-                pass
-        elif q.isdigit() and target_index == -1:
-            try:
-                target_index = int(q)
-            except Exception:
-                pass
-        else:
-            filtered_queries.append(q)
-    queries = filtered_queries
+    queries, target_index, target_addr = split_queries(queries)
 
     norm_queries = [normalize(q) for q in queries]
     raw_queries = [q.lower() for q in queries]
-    addr_queries = [q.lower() for q in queries if q.startswith("0x") or (len(q) > 4 and all(c in "0123456789abcdef" for c in q.lower().replace("0x", "")))]
 
     is_terminal_query = bool(queries and is_terminal_identifier(queries[0]))
     target_cli = ""
@@ -376,7 +421,6 @@ def main():
 
     matching = []
     for c in clients:
-        c_addr = str(c.get("address", "")).lower()
         c_class = str(c.get("class", "")).lower()
         c_init_class = str(c.get("initialClass", "")).lower()
         c_title = str(c.get("title", "")).lower()
@@ -386,11 +430,6 @@ def main():
         c_pid = c.get("pid")
         is_client_terminal = is_terminal_identifier(c_class) or is_terminal_identifier(c_init_class)
         cli_app = extract_cli_app(c_title, c_pid) if is_client_terminal else ""
-
-        if addr_queries:
-            if c_addr in addr_queries:
-                matching.append(c)
-            continue
 
         if target_cli:
             # When clicking a dedicated CLI app icon (e.g. yazi, nvim), match if the terminal window is running that CLI app
@@ -408,7 +447,7 @@ def main():
         is_match = False
         for i, q in enumerate(raw_queries):
             nq = norm_queries[i]
-            if q == c_addr or q == c_class or q == c_init_class:
+            if q == c_class or q == c_init_class:
                 is_match = True
                 break
             if nq and (nq == c_norm_class or nq == c_norm_init):
@@ -447,27 +486,19 @@ def main():
         if not matching:
             return
 
-        target_c = None
-        if target_index >= 0 and target_index < len(matching):
-            target_c = matching[target_index]
-        else:
-            active_addr = ""
-            try:
-                active_raw = hypr_cmd(sock_path, "j/activewindow")
-                if active_raw:
-                    active_obj = json.loads(active_raw)
-                    active_addr = str(active_obj.get("address", "")).lower()
-            except Exception:
-                pass
-            active_matches = [c for c in matching if str(c.get("address", "")).lower() == active_addr]
-            if active_matches:
-                target_c = active_matches[0]
-            elif visible_windows:
-                target_c = visible_windows[0]
-            elif minimized_windows:
-                target_c = minimized_windows[0]
-            else:
-                target_c = matching[0]
+        active_addr = ""
+        try:
+            active_raw = hypr_cmd(sock_path, "j/activewindow")
+            if active_raw:
+                active_obj = json.loads(active_raw)
+                active_addr = str(active_obj.get("address", "")).lower()
+        except Exception:
+            pass
+
+        target_c = pick_target(matching, visible_windows, minimized_windows,
+                               target_addr, target_index, active_addr)
+        if target_c is None:
+            return
 
         addr = target_c["address"]
         is_min = str(target_c.get("workspace", {}).get("name", "")).startswith("special:")
@@ -526,16 +557,10 @@ def main():
             launch_fallback(queries)
             return
 
-        target_c = None
-        if target_index >= 0 and target_index < len(matching):
-            target_c = matching[target_index]
-        else:
-            if visible_windows:
-                target_c = visible_windows[0]
-            elif minimized_windows:
-                target_c = minimized_windows[0]
-            else:
-                target_c = matching[0]
+        target_c = pick_target(matching, visible_windows, minimized_windows,
+                               target_addr, target_index, "")
+        if target_c is None:
+            return
 
         addr = target_c["address"]
         is_min = str(target_c.get("workspace", {}).get("name", "")).startswith("special:")

--- a/tests/test_dock_minimize.py
+++ b/tests/test_dock_minimize.py
@@ -1,0 +1,90 @@
+"""Unit tests for scripts/dock-minimize.py.
+
+Run with:  python3 -m unittest discover -s tests
+"""
+
+import importlib.util
+import os
+import unittest
+
+_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       os.pardir, "scripts", "dock-minimize.py")
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("dock_minimize", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dm = _load_script()
+
+
+def _client(addr, workspace="1"):
+    return {"address": addr, "workspace": {"name": workspace}}
+
+
+class SplitQueriesTest(unittest.TestCase):
+    def test_an_address_is_a_selector_and_leaves_the_app_identifiers_alone(self):
+        # A dock click sends the app's identifiers *and* which window to act on.
+        # Narrowing the match down to the address hides the app's siblings.
+        identifiers, index, addr = dm.split_queries(
+            ["firefox", "firefox.desktop", "/usr/bin/firefox", "0xDEADBEEF"])
+        self.assertEqual(identifiers, ["firefox", "firefox.desktop", "/usr/bin/firefox"])
+        self.assertEqual(index, -1)
+        self.assertEqual(addr, "0xdeadbeef")
+
+    def test_the_legacy_index_selector_still_works(self):
+        self.assertEqual(dm.split_queries(["firefox", "--index=2"]), (["firefox"], 2, ""))
+        self.assertEqual(dm.split_queries(["firefox", "2"]), (["firefox"], 2, ""))
+
+    def test_no_selector_at_all(self):
+        self.assertEqual(dm.split_queries(["firefox"]), (["firefox"], -1, ""))
+
+    def test_an_app_identifier_that_merely_looks_like_hex_is_kept(self):
+        identifiers, _, addr = dm.split_queries(["deface", "facade"])
+        self.assertEqual(identifiers, ["deface", "facade"])
+        self.assertEqual(addr, "")
+
+
+class PickTargetTest(unittest.TestCase):
+    def setUp(self):
+        self.first = _client("0xAAA")
+        self.second = _client("0xBBB")
+        self.hidden = _client("0xCCC", "special:minimized")
+        self.matching = [self.first, self.second, self.hidden]
+        self.visible = [self.first, self.second]
+        self.minimized = [self.hidden]
+
+    def _pick(self, addr="", index=-1, active=""):
+        return dm.pick_target(self.matching, self.visible, self.minimized, addr, index, active)
+
+    def test_an_address_names_the_window_outright(self):
+        self.assertIs(self._pick(addr="0xbbb"), self.second)
+
+    def test_an_address_wins_over_an_index(self):
+        self.assertIs(self._pick(addr="0xbbb", index=0), self.second)
+
+    def test_an_index_is_used_when_no_address_was_given(self):
+        self.assertIs(self._pick(index=1), self.second)
+
+    def test_an_address_that_is_gone_falls_through_to_the_heuristics(self):
+        self.assertIs(self._pick(addr="0xffff", active="0xbbb"), self.second)
+
+    def test_the_active_window_comes_before_the_first_visible_one(self):
+        self.assertIs(self._pick(active="0xbbb"), self.second)
+
+    def test_the_first_visible_window_is_the_default(self):
+        self.assertIs(self._pick(), self.first)
+
+    def test_a_minimized_window_is_the_last_resort(self):
+        self.assertIs(
+            dm.pick_target(self.matching, [], self.minimized, "", -1, ""), self.hidden)
+
+    def test_nothing_matched_at_all(self):
+        self.assertIsNone(dm.pick_target([], [], [], "", -1, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`scripts/dock-minimize.py` already accepts a Hyprland address among its query arguments, but it treats that address as the **match filter** rather than as a selector among the app's own windows. Nothing in the dock passes an address today, so this is latent on `main` — it becomes reachable the moment a click names its target window by address instead of by position, which is what #16 does. Splitting it out so the script fix can land first — #16 regresses right-click minimize unless this one goes in with it.

### What is broken

An address goes into `queries` alongside the app identifiers, and the client loop then matches on it alone:

```python
addr_queries = [q.lower() for q in queries if q.startswith("0x") or (len(q) > 4 and all(c in "0123456789abcdef" for c in q.lower().replace("0x", "")))]
...
if addr_queries:
    if c_addr in addr_queries:
        matching.append(c)
    continue
```

`matching` therefore collapses to the single target window, and `visible_windows`, derived from it, can never hold a sibling. The "focus something else after minimizing" step always finds `other_visible` empty and falls through to `remaining` — an arbitrary client on the focused workspace, in Hyprland's list order. Minimizing one of Firefox's three windows would stop focusing another Firefox window and start focusing whatever else happened to be around.

The detection is also loose: `len(q) > 4 and all(c in "0123456789abcdef" ...)` accepts any hex-looking string, so an app identifier like `deface` would be read as an address. That was harmless while the value was only a filter; it stops being harmless once the value is pulled out of the query list.

### What this PR does

- `split_queries()` separates the app identifiers from the window selector, the way `--index=N` was already separated. The identifiers keep driving the match; the address only picks the target out of the windows that matched.
- `pick_target()` gives both selection sites one shared helper: address first, then index, then active window, then first visible, then minimized. An address whose window is gone falls through instead of aiming at nothing.
- Only a `0x` prefix counts as an address now. Hyprland always writes them that way.
- Adds `tests/test_dock_minimize.py` — stdlib `unittest`, no new dependency. The script had no tests at all.

### Verification

```
$ python3 -m unittest discover -s tests -p 'test_*.py'
Ran 12 tests in 0.000s
OK

$ QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/
Totals: 68 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
