### PR TITLE
fix(cycle): aim a dock click at a window's address, not its position

### DIFF
--- a/DockMatcher.js
+++ b/DockMatcher.js
@@ -1075,6 +1075,27 @@ function findEntryFast(index, appId) {
     return findEntry(index.list, appId);
 }
 
+// The Hyprland address of one of a dock item's windows, empty when the window
+// is not in Hyprland's list any more. A dock icon numbers its windows in its
+// own sticky creation order, while the helper script resolves them against
+// Hyprland's client list, and that list reorders on its own — a lock screen, a
+// workspace move or a restore from the scratchpad is enough to swap two entries
+// around. A position sent across that gap names whichever window happens to sit
+// there; an address names the window itself.
+function hyprAddressFor(toplevel, hyprToplevels) {
+    if (!toplevel || !hyprToplevels || typeof hyprToplevels.length !== "number") return "";
+    for (var i = 0; i < hyprToplevels.length; i++) {
+        var ht = hyprToplevels[i];
+        if (!ht) continue;
+        if (ht === toplevel || ht.wayland === toplevel) {
+            var addr = String(ht.address || "");
+            if (!addr) return "";
+            return addr.indexOf("0x") === 0 ? addr : ("0x" + addr);
+        }
+    }
+    return "";
+}
+
 function collectMatchingToplevels(appId, entry, entries, toplevels, assignedTops, toplevelCliApps, activeToplevel, isTopMinimizedFn, getTopKeyFn) {
     var matching = [];
     var isAnyActive = false;

--- a/DockModel.js
+++ b/DockModel.js
@@ -13,6 +13,7 @@
 // =========================================================================
 var DEFAULT_PINNED = Pinned.DEFAULT_PINNED;
 var stripDesktop = Pinned.stripDesktop;
+var hyprAddressFor = Matcher.hyprAddressFor;
 var toArray = Pinned.toArray;
 var parsePinned = Pinned.parsePinned;
 var serializePinned = Pinned.serializePinned;

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -1609,13 +1609,31 @@ Item {
         }
     }
 
+    // Which window the helper script should act on, as a Hyprland address.
+    // The script resolves a bare --index against Hyprland's client list, which
+    // is ordered independently of the dock's own window order, so the two agree
+    // only until Hyprland reshuffles. Name the window instead, and fall back to
+    // the position only when the address cannot be resolved.
+    function targetWindowArg(itemData, targetIndex) {
+        if (!itemData || typeof targetIndex !== "number" || targetIndex < 0) return ""
+        var tops = itemData.toplevels || []
+        if (targetIndex >= tops.length) return ""
+        var hyprTops = (typeof Hyprland !== "undefined" && Hyprland.toplevels && Hyprland.toplevels.values)
+            ? Hyprland.toplevels.values
+            : []
+        return DockModel.hyprAddressFor(tops[targetIndex], hyprTops)
+    }
+
     function minimizeItem(itemData, targetIndex) {
         if (!itemData) return
         var args = ["minimize-instance"]
         if (itemData.appId) args.push(itemData.appId)
         if (itemData.desktopId && itemData.desktopId !== itemData.appId) args.push(itemData.desktopId)
         if (itemData.exec) args.push(itemData.exec)
-        if (typeof targetIndex === "number" && targetIndex >= 0) {
+        var targetArg = root.targetWindowArg(itemData, targetIndex)
+        if (targetArg) {
+            args.push(targetArg)
+        } else if (typeof targetIndex === "number" && targetIndex >= 0) {
             args.push("--index=" + targetIndex)
         }
         var scriptPath = Qt.resolvedUrl("scripts/dock-minimize.py").toString().replace(/^file:\/\//, "")
@@ -1639,7 +1657,10 @@ Item {
         if (itemData.appId) args.push(itemData.appId)
         if (itemData.desktopId && itemData.desktopId !== itemData.appId) args.push(itemData.desktopId)
         if (itemData.exec) args.push(itemData.exec)
-        if (typeof targetIndex === "number" && targetIndex >= 0) {
+        var targetArg = root.targetWindowArg(itemData, targetIndex)
+        if (targetArg) {
+            args.push(targetArg)
+        } else if (typeof targetIndex === "number" && targetIndex >= 0) {
             args.push("--index=" + targetIndex)
         }
         var scriptPath = Qt.resolvedUrl("scripts/dock-minimize.py").toString().replace(/^file:\/\//, "")

--- a/tests/tst_DockMatcher.qml
+++ b/tests/tst_DockMatcher.qml
@@ -83,4 +83,47 @@ TestCase {
         compare(resAllMin.isActive, false) // Minimized cannot be active
         compare(resAllMin.isMinimized, true)
     }
+
+    // A dock icon numbers its windows in its own sticky creation order, but the
+    // helper script resolves a window against Hyprland's client list, whose
+    // order changes on its own — a lock screen, a workspace move or a restore
+    // from the scratchpad is enough. Passing a position therefore aims at
+    // whichever window happens to sit there now; an address names one window.
+    function test_hyprAddressForFindsTheWindowByIdentity() {
+        var firstWayland = { title: "first" }
+        var secondWayland = { title: "second" }
+        var hyprToplevels = [
+            { address: "0xaaa111", wayland: firstWayland },
+            { address: "0xbbb222", wayland: secondWayland }
+        ]
+        compare(DockMatcher.hyprAddressFor(secondWayland, hyprToplevels), "0xbbb222")
+        compare(DockMatcher.hyprAddressFor(firstWayland, hyprToplevels), "0xaaa111")
+    }
+
+    function test_hyprAddressForPrefixesABareHexAddress() {
+        // The script recognises an address only by its 0x prefix, so a bare
+        // address from Hyprland has to grow one before it is passed along.
+        var wayland = { title: "first" }
+        compare(DockMatcher.hyprAddressFor(wayland, [{ address: "ccc333", wayland: wayland }]), "0xccc333")
+    }
+
+    function test_hyprAddressForIgnoresPositionAndOrder() {
+        // The same window keeps its address after Hyprland reshuffles its list.
+        var wayland = { title: "first" }
+        var before = [{ address: "0xaaa111", wayland: wayland }, { address: "0xbbb222", wayland: {} }]
+        var after = [{ address: "0xbbb222", wayland: {} }, { address: "0xaaa111", wayland: wayland }]
+        compare(DockMatcher.hyprAddressFor(wayland, before), DockMatcher.hyprAddressFor(wayland, after))
+    }
+
+    function test_hyprAddressForReturnsNothingForAnUnknownWindow() {
+        // A window that closed between the click and the lookup has no address,
+        // and the caller falls back rather than aiming at a stranger.
+        compare(DockMatcher.hyprAddressFor({ title: "gone" }, [{ address: "0xaaa111", wayland: {} }]), "")
+    }
+
+    function test_hyprAddressForHandlesMissingOperands() {
+        compare(DockMatcher.hyprAddressFor(null, [{ address: "0xaaa111", wayland: {} }]), "")
+        compare(DockMatcher.hyprAddressFor({ title: "first" }, null), "")
+        compare(DockMatcher.hyprAddressFor(null, null), "")
+    }
 }


### PR DESCRIPTION
Left-clicking a dock icon to cycle its windows stops working after a lock screen, and keeps not working until the shell is restarted.

### What is broken

A dock icon lists its windows in the order they opened, and `syncKnownWindows` preserves that order deliberately. `dock-minimize.py`, on the other side of the call, resolves the `--index` it is handed against `hyprctl`'s client list — which Hyprland reorders on its own. A lock screen is enough to break the agreement: after unlocking, my two Firefox windows had swapped places in Hyprland's list while the dock still held the original order.

Left-clicking a focused app then asks for `(activeTopIndex + 1) % 2`, which in the reversed list is the window already in focus, so the click does nothing — and every click after it repeats the same no-op, because nothing about the state has changed. Restarting the shell rebuilds the dock's order from Hyprland's current one and hides the bug until the next lock, which is why it kept coming back.

Right-click minimize aims by the same index and is wrong in the same way.

### What this PR does

Resolves the target window to its Hyprland address and passes that instead. A position sent across that gap names whichever window happens to sit there; an address names the window itself. The index stays as a fallback for a window the lookup cannot place.

- `DockMatcher.hyprAddressFor(toplevel, hyprToplevels)` — the address of one of a dock item's windows, `""` when the window is not in Hyprland's list any more. Bare addresses grow a `0x` prefix, since that is the only form the script recognises.
- `DockPanel.targetWindowArg()` — one place that decides what to send, used by both `minimizeItem()` and the cycle path.

### Depends on #15

The script treats an address as its match filter, so on `main` an address would collapse `matching` to the single target window and the post-minimize focus step would then focus an unrelated client. #15 makes the address a selector instead. **Merging this one first would regress right-click minimize**, so it should go second — or both together.

### Verification

```
$ QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/
Totals: 73 passed, 0 failed
```

5 new tests in `tst_DockMatcher.qml` cover identity lookup, the `0x` prefix, order independence, an unknown window and missing operands. On a live session, cycling two Firefox windows after a lock screen now alternates instead of no-opping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
