### PR TITLE
fix(fullscreen): keep an autohidden dock reachable without swallowing the screen edge

### DIFF
--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -2451,7 +2451,12 @@ Item {
                 }
 
                 WlrLayershell.namespace: "omarchy-dock"
-                WlrLayershell.layer: WlrLayer.Top
+                // Fullscreen windows stack above the Top layer, which would
+                // leave an autohidden dock unreachable exactly when it is
+                // summoned. Overlay keeps it callable there. In "always" mode
+                // the dock is permanently on screen, so it stays on Top and
+                // lets fullscreen content win.
+                WlrLayershell.layer: root.autohide ? WlrLayer.Overlay : WlrLayer.Top
                 WlrLayershell.keyboardFocus: root.isEditMode ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
                 exclusionMode: root.dockRevealed && !root.overlayMode ? ExclusionMode.Auto : ExclusionMode.Ignore
                 color: "transparent"
@@ -3123,7 +3128,9 @@ Item {
                          && root.screenShowsDock(modelData)
 
                 WlrLayershell.namespace: "omarchy-dock-edge"
-                WlrLayershell.layer: WlrLayer.Top
+                // The reveal trigger only exists while autohide is on, and it
+                // has to catch the pointer over a fullscreen window.
+                WlrLayershell.layer: WlrLayer.Overlay
                 WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
                 exclusionMode: ExclusionMode.Ignore
                 color: "transparent"

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -2461,6 +2461,18 @@ Item {
                 exclusionMode: root.dockRevealed && !root.overlayMode ? ExclusionMode.Auto : ExclusionMode.Ignore
                 color: "transparent"
 
+                // Input region. While the dock is slid out its card is
+                // translated off the window and the HoverHandler below is
+                // disabled, so claiming the whole window there only swallows
+                // the outer edge of whatever is underneath -- a fullscreen
+                // client, since autohide puts this window on the Overlay layer
+                // -- for a dock that cannot be hovered anyway. Revealing it is
+                // the separate edge trigger's job. Hand the strip back.
+                mask: Region {
+                    width: root.shouldSlideOut ? 0 : dockLayer.width
+                    height: root.shouldSlideOut ? 0 : dockLayer.height
+                }
+
                 anchors {
                     top: root.barPosition === "bottom"
                     bottom: root.barPosition === "top"


### PR DESCRIPTION
Two related things an autohidden dock gets wrong at the screen edge, both about fullscreen windows. Separate commits, but they only make sense together: the first moves the dock to the Overlay layer, the second stops that move costing the edge.

### 1. An autohidden dock is unreachable over a fullscreen window

Both dock surfaces sit on the `Top` layer, which fullscreen windows stack above. Hovering the screen edge under a fullscreen window therefore does nothing: the trigger never sees the pointer, and the dock would have rendered underneath anyway.

The reveal trigger moves to `Overlay` unconditionally — it only exists while autohide is on, and catching the pointer over a fullscreen window is its whole job. The dock window moves to `Overlay` only when autohide is on; in `always` mode the dock is permanently on screen, so it stays on `Top` and lets fullscreen content win rather than parking a strip over every video.

Verified with a fullscreen window: both `omarchy-dock` and `omarchy-dock-edge` report layer level 3 instead of 2, with the dock hidden and its trigger mapped.

### 2. …and once it is on Overlay, it swallows the screen edge

The dock window is never unmapped while hidden — only its card is translated off it — and it declares no input region, so its full ~50px thickness keeps claiming pointer input on `Overlay` the whole time. Its own `HoverHandler` is disabled while slid out, so the strip is not even the thing that reveals the dock (the separate 4px edge trigger is). A fullscreen game or video loses the outer 50px along the dock's edge for nothing.

The window now gets an input region that collapses to nothing while the dock is slid out and covers it as before once revealed:

```qml
mask: Region {
    width: root.shouldSlideOut ? 0 : dockLayer.width
    height: root.shouldSlideOut ? 0 : dockLayer.height
}
```

### Verification

```
$ QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/
Totals: 68 passed, 0 failed
```

Both changes are QML-only and not test-covered; verified on a live session against a fullscreen window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
