### PR TITLE
fix(autohide): ask the shell whether a panel is really open

### DIFF
--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -542,8 +542,16 @@ Item {
             }
         }
         if (root.shell && root.shell.openPanelIds) {
+            // openPanelIds is a set the shell adds to on summon and removes
+            // from on hide, so a panel that closes itself can leave its id
+            // behind. The shell's own isPluginOpen() knows this and prefers
+            // the panel's live `opened` property, falling back to the set only
+            // when there is nothing live to ask. Trusting the raw set instead
+            // pins the dock open for the rest of the session.
+            var askShell = typeof root.shell.isPluginOpen === "function"
             for (var k in root.shell.openPanelIds) {
-                if (root.shell.openPanelIds[k] === true) return true
+                if (root.shell.openPanelIds[k] !== true) continue
+                if (!askShell || root.shell.isPluginOpen(k)) return true
             }
         }
         return false


### PR DESCRIPTION
Switching themes leaves the dock revealed for the rest of the session.

### What is broken

`checkWidgetPanelsOpen()` reads `shell.openPanelIds` directly:

```qml
if (root.shell && root.shell.openPanelIds) {
    for (var k in root.shell.openPanelIds) {
        if (root.shell.openPanelIds[k] === true) return true
    }
}
```

That set only loses an id when something calls the shell's `hide()`. A panel that closes itself leaves its entry behind, so the set says "open" forever, and the dock has no way back to hidden.

The theme picker runs on `omarchy.image-picker`, which is `keepLoaded` and closes itself, so it is one of the panels that strands an entry — as is `omarchy.menu`. A capture after switching themes showed both sitting in the set with their live state `false`.

`isDockHovered` getting stuck is downstream of this rather than a second bug: `evaluateHoverState()` folds open panels into `anyHover`, and that branch stops the leave timer and pins the flag true.

### What this PR does

The shell already knows about this: its own `isPluginOpen()` consults the panel's live `opened` property first and falls back to the set only when there is nothing live to ask. Ask through it instead of reading the raw map, and keep the raw read as the fallback for a shell that does not expose the function.

### Verification

```
$ QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/
Totals: 68 passed, 0 failed
```

On a live session: after switching themes, `checkWidgetPanelsOpen()` now returns `false` where before it returned `true`, and the dock hides again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
