### PR TITLE
fix(autohide): re-derive hover state after the dock surfaces remap

### DIFF
--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -1326,12 +1326,21 @@ Item {
         id: remapTimer
         interval: 100
         repeat: false
+        // The remap builds fresh surfaces whose HoverHandlers start out
+        // unhovered and therefore emit no onHoveredChanged. Re-derive the
+        // hover state by hand, or a dock that was hovered before the remap
+        // would stay revealed with nothing left to ever clear the flag.
+        onTriggered: root.evaluateHoverState()
     }
 
     property string lastRemapBarPosition: ""
     onBarPositionChanged: {
         if (root.lastRemapBarPosition !== root.barPosition) {
             root.lastRemapBarPosition = root.barPosition
+            // Drop the sticky hover flag before the surfaces are rebuilt: the
+            // pointer cannot be over a dock that does not exist yet, and the
+            // edge trigger re-reveals the dock the moment it really is.
+            root.isDockHovered = false
             remapTimer.restart()
         }
     }


### PR DESCRIPTION
Move the bar to another edge while the pointer rests on an autohidden dock, and the dock never hides again until the shell restarts.

### What is broken

A remap tears the dock surfaces down and builds new ones. Their `HoverHandler`s are born unhovered, so when the pointer is not over the rebuilt dock they emit no `onHoveredChanged` at all.

`isDockHovered` is sticky state: nothing clears it but `autohideLeaveTimer`, the timer only restarts from `evaluateHoverState()`, and every one of that function's call sites is event-driven. With no event to run it, a dock that was hovered before the remap stays revealed permanently.

`remapTimer` exists for exactly this window but has no `onTriggered` — it only gates the unmap/remap sequence.

### What this PR does

- `remapTimer.onTriggered: root.evaluateHoverState()` — re-derive the hover state once the remap settles.
- Drop the stale flag up front when the bar changes edge: the pointer cannot be over a dock that does not exist yet, and the edge trigger re-reveals the dock the moment it really is.

The screen-change path already routes through the same timer, so a monitor or scale change is covered too.

Polling would not work here, for what it is worth: the unhovered branch restarts a 1.5s one-shot, so re-running it on an interval would stop it ever firing.

### Verification

```
$ QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/
Totals: 68 passed, 0 failed
```

QML-only, not test-covered. On a live session, forcing repeated remaps: before, the `omarchy-dock-edge` trigger was absent afterwards on every edge and the dock stayed revealed; after, the dock hides with its trigger mapped every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
