### PR TITLE
feat(tooltip): label the hovered dock icon

### DIFF
--- a/DockItem.qml
+++ b/DockItem.qml
@@ -41,6 +41,10 @@ Item {
     signal minimizeRequested(var itemData, int targetIndex)
     signal dragStarted(int fromIndex)
     signal dragEnded()
+    // Reported in this item's window coordinates so the tooltip window can
+    // line itself up with the icon without re-deriving the dock layout.
+    signal tooltipRequested(var itemData, point windowCenter)
+    signal tooltipDismissed(var itemData)
 
     readonly property int badgeCount: (root.itemData && typeof root.itemData.badgeCount === "number") ? root.itemData.badgeCount : 0
 
@@ -510,6 +514,7 @@ Item {
 
         onEntered: {
             mouseArea.forceActiveFocus()
+            root.tooltipRequested(root.itemData, root.mapToItem(null, root.width / 2, root.height / 2))
         }
 
         Keys.onRightPressed: function(event) {
@@ -661,6 +666,7 @@ Item {
             longPressTimer.stop()
             root.isWheelScrolling = false
             previewResetTimer.restart()
+            root.tooltipDismissed(root.itemData)
         }
 
         onCanceled: {

--- a/DockMatcher.js
+++ b/DockMatcher.js
@@ -1075,6 +1075,63 @@ function findEntryFast(index, appId) {
     return findEntry(index.list, appId);
 }
 
+// Do two dock item objects describe the same icon? The model is rebuilt
+// whenever windows change, so object identity alone is not enough. Items
+// with no identity at all never match: treating them as equal would let one
+// icon's hover exit cancel another icon's tooltip.
+function isSameDockItem(a, b) {
+    if (a && b && a === b) return true;
+    if (!a || !b) return false;
+    var aId = String(a.id || a.appId || "");
+    var bId = String(b.id || b.appId || "");
+    return aId.length > 0 && aId === bId;
+}
+
+// True while the given dock item is still one of the icons on the dock. A
+// delegate destroyed under the pointer -- an app's last window closed while its
+// unpinned icon was hovered -- delivers no exit signal, so whoever tracks the
+// hovered icon has to notice the rebuild instead.
+function dockItemStillPresent(item, items) {
+    if (!item || !items || typeof items.length !== "number") return false;
+    for (var i = 0; i < items.length; i++) {
+        if (isSameDockItem(item, items[i])) return true;
+    }
+    return false;
+}
+
+// Longest tooltip we will render, ellipsis included. Window titles are
+// unbounded, and an untrimmed one runs off the side of the screen.
+var TOOLTIP_MAX_LENGTH = 60;
+
+function truncateTooltip(text) {
+    var value = String(text == null ? "" : text).trim();
+    if (value.length <= TOOLTIP_MAX_LENGTH) return value;
+    return value.slice(0, TOOLTIP_MAX_LENGTH - 1) + "\u2026";
+}
+
+// Label for a hovered dock item. A single window is best identified by its
+// own title; several windows have no one title that is honest, so name the
+// app and say how many. Folders and idle apps just carry their name.
+function tooltipTextFor(item) {
+    if (!item || typeof item !== "object") return "";
+
+    var name = String(item.name || "").trim();
+    if (item.isStack) return truncateTooltip(name);
+
+    var count = (typeof item.windowCount === "number" && item.windowCount > 0)
+        ? item.windowCount : 0;
+    if (count === 0) return truncateTooltip(name);
+
+    if (count === 1) {
+        var tops = Array.isArray(item.toplevels) ? item.toplevels : [];
+        var top = tops.length > 0 ? tops[0] : null;
+        var title = top ? String(top.title || "").trim() : "";
+        return truncateTooltip(title || name);
+    }
+
+    return truncateTooltip(name + " \u00b7 " + count + " windows");
+}
+
 function collectMatchingToplevels(appId, entry, entries, toplevels, assignedTops, toplevelCliApps, activeToplevel, isTopMinimizedFn, getTopKeyFn) {
     var matching = [];
     var isAnyActive = false;

--- a/DockModel.js
+++ b/DockModel.js
@@ -13,6 +13,9 @@
 // =========================================================================
 var DEFAULT_PINNED = Pinned.DEFAULT_PINNED;
 var stripDesktop = Pinned.stripDesktop;
+var tooltipTextFor = Matcher.tooltipTextFor;
+var isSameDockItem = Matcher.isSameDockItem;
+var dockItemStillPresent = Matcher.dockItemStillPresent;
 var toArray = Pinned.toArray;
 var parsePinned = Pinned.parsePinned;
 var serializePinned = Pinned.serializePinned;

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -642,6 +642,63 @@ Item {
         onTriggered: root.refreshActiveWorkspaceWindowCount()
     }
 
+
+    // --- Icon tooltip ---------------------------------------------------
+    property var tooltipItem: null
+    // Centre of the hovered icon, in dock-window coordinates.
+    property point tooltipWindowCenter: Qt.point(0, 0)
+    property bool tooltipShown: false
+    readonly property string tooltipText: DockModel.tooltipTextFor(root.tooltipItem)
+
+    // Same centre, along the axis the dock runs on, in screen coordinates.
+    // The dock window is centred on that axis, so its origin is half the
+    // leftover screen length.
+    readonly property real tooltipAxisCenter: {
+        var win = root.dockWindow
+        if (!win || !win.screen) return 0
+        var screenLength = root.isVertical ? win.screen.height : win.screen.width
+        var windowLength = root.isVertical ? win.height : win.width
+        var origin = (screenLength - windowLength) / 2
+        return origin + (root.isVertical ? root.tooltipWindowCenter.y : root.tooltipWindowCenter.x)
+    }
+
+    Timer {
+        id: tooltipDelayTimer
+        interval: 450
+        repeat: false
+        onTriggered: root.tooltipShown = (root.tooltipItem !== null && root.tooltipText.length > 0)
+    }
+
+    function requestTooltip(itemData, windowCenter) {
+        if (!itemData || root.isEditMode || root.dockDragActiveIndex >= 0) return
+        root.tooltipItem = itemData
+        root.tooltipWindowCenter = windowCenter
+        tooltipDelayTimer.restart()
+    }
+
+    // Leaving an icon cancels only that icon's tooltip. The pointer crossing
+    // from one icon to the next can deliver the old icon's exit *after* the
+    // new icon's enter, and an unconditional cancel would kill the tooltip
+    // that was just asked for. Calling this with no item (dock hiding, drag,
+    // popup) always clears.
+    function dismissTooltip(itemData) {
+        if (itemData !== undefined && itemData !== null && root.tooltipItem !== null
+                && !DockModel.isSameDockItem(itemData, root.tooltipItem)) return
+        tooltipDelayTimer.stop()
+        root.tooltipShown = false
+        root.tooltipItem = null
+    }
+
+    // A delegate destroyed while the pointer is on it never emits its exit, so
+    // the rebuilt dock is the only notice that the labelled icon is gone --
+    // close an unpinned app's last window and the icon disappears from under
+    // the pointer, leaving the label naming an app that is no longer there.
+    onDockItemsChanged: {
+        if (root.tooltipItem !== null && !DockModel.dockItemStillPresent(root.tooltipItem, root.dockItems)) {
+            root.dismissTooltip()
+        }
+    }
+
     readonly property bool isWorkspaceEmpty: root.activeWorkspaceWindowCount === 0
     readonly property bool isDockActive: root.isDockHovered
         || root.isStackHovered
@@ -1327,6 +1384,9 @@ Item {
         interval: 100
         repeat: false
     }
+
+    onShouldSlideOutChanged: if (root.shouldSlideOut) root.dismissTooltip()
+    onDockDragActiveIndexChanged: if (root.dockDragActiveIndex >= 0) root.dismissTooltip()
 
     property string lastRemapBarPosition: ""
     onBarPositionChanged: {
@@ -2385,6 +2445,7 @@ Item {
     }
 
     onIsEditModeChanged: {
+        if (root.isEditMode) root.dismissTooltip()
         if (isEditMode) {
             var win = root.dockWindow
             if (win && win.surface) win.surface.forceActiveFocus()
@@ -2393,6 +2454,7 @@ Item {
     }
 
     onIsStackOpenChanged: {
+        if (root.isStackOpen) root.dismissTooltip()
         if (isStackOpen) {
             if (stackWindow && stackWindow.stackCard) stackWindow.stackCard.forceActiveFocus()
         }
@@ -2400,6 +2462,7 @@ Item {
     }
 
     onIsMenuOpenChanged: {
+        if (root.isMenuOpen) root.dismissTooltip()
         if (isMenuOpen) {
             if (menuWindow && menuWindow.menuCard) {
                 menuWindow.menuCard.forceActiveFocus()
@@ -2777,6 +2840,9 @@ Item {
                         isSelected: (!root.isMenuFromFolder && root.activeMenuItem && (root.activeMenuItem.appId === modelData.appId || root.activeMenuItem.id === modelData.id)) || (root.activeStackItem && (root.activeStackItem.id === modelData.id || root.activeStackItem.appId === modelData.appId))
                         isMergeTarget: (root.currentMergeTargetIndex === index)
 
+                        onTooltipRequested: function(data, windowCenter) { root.requestTooltip(data, windowCenter) }
+                        onTooltipDismissed: function(data) { root.dismissTooltip(data) }
+
                         // 1D Live Rail Displacement (with Left Widget offset)
                         readonly property real appBaseOffset: (root.hasLeftWidgets ? (root.leftWidgetsWidth + root.leftSeparatorSize) : 0)
                         readonly property int visualSlot: (root.dockDragActiveIndex === index) ? index : root.getDockVisualSlot(index, root.dockDragActiveIndex, root.dockDragTargetIndex)
@@ -3084,6 +3150,12 @@ Item {
     }
 
     // 2. The Isolated Action Card Popup Overlay Window (Folder Icon Picker)
+    DockTooltip {
+        id: tooltipWindow
+        root: root
+        dockWindow: root.dockWindow
+    }
+
     FolderMenu {
         id: menuWindow
         root: root

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ target. In `keybind` and `hybrid` modes, summoned docks automatically hide after
 the same 1.5-second inactivity delay used by hover mode. Keeping the pointer or
 a dock popup active pauses the dismissal timer.
 
+Hovering an icon for about half a second labels it: the window's own title
+when the app has exactly one window open, the app name and a window count
+when it has several, and just the name for a folder or an app that is not
+running. The label never takes pointer input, so it cannot steal the hover
+that summoned it.
+
 Pinned items and folder layouts are automatically saved to `~/.config/omarchy/dock-pinned.json`.
 
 ---

--- a/components/DockTooltip.qml
+++ b/components/DockTooltip.qml
@@ -1,0 +1,97 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.Commons
+import qs.Ui
+import ".."
+
+// Label for the dock icon under the pointer. Deliberately inert: it never
+// takes pointer or keyboard input, because catching the pointer would pull
+// hover off the icon that summoned it and flicker the tooltip away.
+PanelWindow {
+    id: tipWindow
+
+    required property var root
+    required property var dockWindow
+
+    readonly property string text: tipWindow.root.tooltipText
+    readonly property bool vertical: tipWindow.root.isVertical
+
+    // Clear the dock card and the gap on either side of it.
+    readonly property int dockGap: (Style.gapsOut || 5)
+    readonly property int dockOffset: dockGap + (tipWindow.root.slotSize + 8) + dockGap
+
+    visible: tipWindow.root.tooltipShown
+             && tipWindow.root.dockRevealed
+             && tipWindow.text.length > 0
+
+    screen: tipWindow.dockWindow ? tipWindow.dockWindow.screen : null
+
+    WlrLayershell.namespace: "omarchy-dock-tooltip"
+    // Matches the dock: a tooltip for a dock summoned over a fullscreen window
+    // has to be able to draw there too.
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    exclusionMode: ExclusionMode.Ignore
+    // Empty input region: the surface is painted but pointer-transparent.
+    mask: Region {}
+    color: "transparent"
+
+    // Span the axis the dock runs along, then place the card by hand at the
+    // hovered icon; anchor across that axis to sit just off the dock.
+    anchors {
+        top: tipWindow.vertical || tipWindow.root.barPosition === "bottom"
+        bottom: tipWindow.vertical || tipWindow.root.barPosition === "top"
+        left: tipWindow.vertical ? (tipWindow.root.barPosition === "right") : true
+        right: tipWindow.vertical ? (tipWindow.root.barPosition === "left") : true
+    }
+
+    margins {
+        top: (!tipWindow.vertical && tipWindow.root.barPosition === "bottom") ? tipWindow.dockOffset : 0
+        bottom: (!tipWindow.vertical && tipWindow.root.barPosition === "top") ? tipWindow.dockOffset : 0
+        left: (tipWindow.vertical && tipWindow.root.barPosition === "right") ? tipWindow.dockOffset : 0
+        right: (tipWindow.vertical && tipWindow.root.barPosition === "left") ? tipWindow.dockOffset : 0
+    }
+
+    implicitWidth: tipWindow.vertical ? card.width : (screen ? screen.width : 1920)
+    implicitHeight: tipWindow.vertical ? (screen ? screen.height : 1080) : card.height
+
+    BorderSurface {
+        id: card
+
+        readonly property int edgePadding: 4
+
+        width: label.implicitWidth + Style.space(16)
+        height: label.implicitHeight + Style.space(10)
+        radius: Style.cornerRadius
+        color: Color.popups.background
+        borderSpec: Border.localOrSurfaceSpec("popups", "border", Color.popups.border,
+                                              Color.popups.border, Style.normalBorderWidth)
+
+        // Centre on the hovered icon, then keep the whole card on screen.
+        x: tipWindow.vertical
+            ? 0
+            : Math.max(edgePadding,
+                Math.min(tipWindow.width - width - edgePadding,
+                         tipWindow.root.tooltipAxisCenter - width / 2))
+        y: tipWindow.vertical
+            ? Math.max(edgePadding,
+                Math.min(tipWindow.height - height - edgePadding,
+                         tipWindow.root.tooltipAxisCenter - height / 2))
+            : 0
+
+        opacity: tipWindow.visible ? 1 : 0
+        Behavior on opacity { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+
+        Text {
+            id: label
+            anchors.centerIn: parent
+            text: tipWindow.text
+            textFormat: Text.PlainText
+            color: Color.popups.text
+            font.family: Style.font.family
+            font.pixelSize: Style.font.body
+            renderType: Text.NativeRendering
+        }
+    }
+}

--- a/tests/tst_DockMatcher.qml
+++ b/tests/tst_DockMatcher.qml
@@ -83,4 +83,138 @@ TestCase {
         compare(resAllMin.isActive, false) // Minimized cannot be active
         compare(resAllMin.isMinimized, true)
     }
+
+    function test_tooltipTextIsEmptyWithoutAnItem() {
+        compare(DockMatcher.tooltipTextFor(null), "")
+        compare(DockMatcher.tooltipTextFor(undefined), "")
+    }
+
+    function test_tooltipShowsTheAppNameWhenNotRunning() {
+        compare(DockMatcher.tooltipTextFor({
+            name: "Firefox", isRunning: false, windowCount: 0, toplevels: []
+        }), "Firefox")
+    }
+
+    function test_tooltipShowsTheFolderNameForAStack() {
+        compare(DockMatcher.tooltipTextFor({
+            name: "Media", isStack: true, isRunning: true, windowCount: 3,
+            toplevels: [{ title: "Some window" }]
+        }), "Media")
+    }
+
+    function test_tooltipShowsTheWindowTitleForASingleWindow() {
+        compare(DockMatcher.tooltipTextFor({
+            name: "Firefox", isRunning: true, windowCount: 1,
+            toplevels: [{ title: "Hyprland Wiki - Variables" }]
+        }), "Hyprland Wiki - Variables")
+    }
+
+    function test_tooltipFallsBackToTheAppNameWhenTheTitleIsBlank_data() {
+        return [
+            { tag: "empty", title: "" },
+            { tag: "whitespace", title: "   " },
+            { tag: "missing", title: undefined }
+        ]
+    }
+
+    function test_tooltipFallsBackToTheAppNameWhenTheTitleIsBlank(data) {
+        compare(DockMatcher.tooltipTextFor({
+            name: "Alacritty", isRunning: true, windowCount: 1,
+            toplevels: [{ title: data.title }]
+        }), "Alacritty")
+    }
+
+    function test_tooltipCountsWindowsInsteadOfPickingOneTitle() {
+        compare(DockMatcher.tooltipTextFor({
+            name: "Nautilus", isRunning: true, windowCount: 3,
+            toplevels: [{ title: "Home" }, { title: "Downloads" }, { title: "Music" }]
+        }), "Nautilus \u00b7 3 windows")
+    }
+
+    function test_tooltipUsesTheSingularCountLabelDefensively() {
+        // windowCount disagreeing with toplevels.length must not read as "1 windows"
+        compare(DockMatcher.tooltipTextFor({
+            name: "Slack", isRunning: true, windowCount: 2, toplevels: []
+        }), "Slack \u00b7 2 windows")
+    }
+
+    function test_tooltipTruncatesOverlongTitles() {
+        var long = "A window title that runs on well past what any sensible tooltip should ever display"
+        var out = DockMatcher.tooltipTextFor({
+            name: "Editor", isRunning: true, windowCount: 1, toplevels: [{ title: long }]
+        })
+        compare(out.length, 60)
+        compare(out.charAt(59), "\u2026")
+        compare(out.slice(0, 59), long.slice(0, 59))
+    }
+
+    function test_tooltipLeavesTitlesAtTheLimitAlone() {
+        var exact = new Array(61).join("x") // 60 chars
+        compare(exact.length, 60)
+        compare(DockMatcher.tooltipTextFor({
+            name: "Editor", isRunning: true, windowCount: 1, toplevels: [{ title: exact }]
+        }), exact)
+    }
+
+    function test_sameDockItemMatchesTheIdenticalObject() {
+        var item = { id: "firefox", appId: "firefox" }
+        verify(DockMatcher.isSameDockItem(item, item))
+    }
+
+    function test_sameDockItemMatchesARebuiltCopyById() {
+        verify(DockMatcher.isSameDockItem({ id: "firefox" }, { id: "firefox" }))
+    }
+
+    function test_sameDockItemFallsBackToAppId() {
+        verify(DockMatcher.isSameDockItem({ appId: "slack" }, { appId: "slack" }))
+    }
+
+    function test_differentDockItemsDoNotMatch() {
+        verify(!DockMatcher.isSameDockItem({ id: "firefox" }, { id: "slack" }))
+    }
+
+    function test_dockItemsWithoutIdentityNeverMatch() {
+        // Two anonymous objects must not be treated as the same icon, or one
+        // icon's exit would cancel another icon's tooltip.
+        verify(!DockMatcher.isSameDockItem({}, {}))
+        verify(!DockMatcher.isSameDockItem({ id: "" }, { id: "" }))
+    }
+
+    function test_sameDockItemHandlesMissingOperands() {
+        verify(!DockMatcher.isSameDockItem(null, { id: "firefox" }))
+        verify(!DockMatcher.isSameDockItem({ id: "firefox" }, null))
+        verify(!DockMatcher.isSameDockItem(null, null))
+    }
+
+    function test_dockItemStillPresentTracksTheRebuiltDock() {
+        var firefox = { id: "firefox" }
+        var slack = { id: "slack" }
+        verify(DockMatcher.dockItemStillPresent(firefox, [slack, firefox]))
+        verify(!DockMatcher.dockItemStillPresent(firefox, [slack]))
+    }
+
+    // The Repeater hands out fresh objects on every rebuild, so identity has to
+    // go through isSameDockItem rather than ===.
+    function test_dockItemStillPresentMatchesARebuiltCopy() {
+        verify(DockMatcher.dockItemStillPresent({ id: "firefox" }, [{ id: "firefox" }]))
+        verify(DockMatcher.dockItemStillPresent({ appId: "slack" }, [{ appId: "slack" }]))
+    }
+
+    function test_dockItemStillPresentOnAnEmptyOrMissingDock_data() {
+        return [
+            { tag: "empty", items: [] },
+            { tag: "null", items: null },
+            { tag: "undefined", items: undefined },
+            { tag: "not-a-list", items: 3 }
+        ]
+    }
+
+    function test_dockItemStillPresentOnAnEmptyOrMissingDock(data) {
+        verify(!DockMatcher.dockItemStillPresent({ id: "firefox" }, data.items))
+    }
+
+    function test_dockItemStillPresentWithoutAnItem() {
+        verify(!DockMatcher.dockItemStillPresent(null, [{ id: "firefox" }]))
+        verify(!DockMatcher.dockItemStillPresent(undefined, [{ id: "firefox" }]))
+    }
 }


### PR DESCRIPTION
A dock icon is the only thing naming an app, and a fallback glyph or an unfamiliar icon leaves you guessing. This labels the icon under the pointer after 450ms:

- the window's own title when the app has exactly one window open,
- `<name> · N windows` when it has several,
- just the name for a folder, or for an app that is not running.

Window titles are unbounded, so they are truncated at 60 characters.

### Shape

The label is a separate `PanelWindow` (`components/DockTooltip.qml`) on the `Overlay` layer — a dock summoned over a fullscreen window has to be able to label itself there too — with an empty input region, so it never pulls the pointer off the icon that summoned it. It anchors across from the bar the way the dock does, so it follows the dock to whichever edge the dock is on, and it spans the axis the dock runs along, placing the card by hand at the hovered icon.

`DockItem` reports the hovered icon's centre in window coordinates, so the tooltip window can line up with the icon without re-deriving the dock layout.

### Lifetime

That is the fiddly part, and three cases need naming:

1. **Crossing between icons.** The pointer moving from one icon to the next can deliver the old icon's exit *after* the new icon's enter, so leaving an icon cancels only that icon's own tooltip (`isSameDockItem`). An unconditional "someone exited, hide it" would kill the label that was just asked for.
2. **A delegate destroyed under the pointer.** Closing an unpinned app's last window rebuilds `dockItems`, the Repeater destroys that delegate and the dock shrinks out from under the pointer — no exit, and no enter either. The label would name a gone app indefinitely in `always` mode. A rebuilt dock that no longer lists the labelled item now clears it (`dockItemStillPresent`).
3. **Everything else.** Sliding out, entering edit mode, starting a drag, opening a stack or a menu clear it outright.

### Testing

The text and identity helpers are pure functions in `DockMatcher.js` — `tooltipTextFor`, `isSameDockItem`, `dockItemStillPresent` — so they are covered rather than left to the QML side:

```
$ QT_QPA_PLATFORM=offscreen qmltestrunner -input tests/
Totals: 92 passed, 0 failed
```

24 new tests in `tst_DockMatcher.qml`. The QML side is verified on a live session.

README gets a paragraph under the visibility section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
