### PR TITLE
fix(widgets): keep a third-party widget enabled while it lives in the dock

### DIFF
--- a/DockWidgets.js
+++ b/DockWidgets.js
@@ -1,8 +1,52 @@
 .pragma library
 
+// Omarchy decides whether a plugin is enabled by finding its id in the shell
+// config -- PluginRegistry.isEnabled() -> findEntryLocation(), which looks at
+// `bar.id`, `bar.layout.*` and the top-level `plugins` array. A first-party
+// widget short-circuits on `__isFirstParty` and is enabled wherever it sits,
+// which is why hosting one in the dock works. A third-party plugin has to be
+// found: taken out of `bar.layout` and listed nowhere else it counts as
+// disabled, gets no Loader, and shell.summon() refuses it -- so the dock slot
+// we just created cannot open it, and neither can anything else.
+//
+// Registering it under `plugins` keeps it enabled with no bar icon, which is
+// where overlay-only plugins already live. We only deregister a widget we
+// registered ourselves, so a plugin the user already had under `plugins`
+// stays there when it leaves the dock.
+function findPluginEntryIndex(config, widgetId) {
+    if (!config || !Array.isArray(config.plugins) || !widgetId) return -1;
+    for (var i = 0; i < config.plugins.length; i++) {
+        var entry = config.plugins[i];
+        var id = (typeof entry === "string") ? entry : (entry && entry.id);
+        if (id === widgetId) return i;
+    }
+    return -1;
+}
+
+// A first-party widget needs no `plugins` entry and adding one would only be
+// noise in the user's config. When the registry is not reachable we register
+// anyway: a redundant entry never disables anything, a missing one does.
+function isFirstPartyWidget(shell, widgetId) {
+    if (!shell || !shell.pluginRegistry || !widgetId) return false;
+    var installed = shell.pluginRegistry.installedPlugins;
+    var manifest = installed ? installed[widgetId] : null;
+    return !!(manifest && manifest.__isFirstParty);
+}
+
 function switchDockWidgetInBar(shell, newWidgetId, prevWidgetIds, savedPositions, shellConfigFile) {
     if (!savedPositions) savedPositions = {};
     if (!Array.isArray(prevWidgetIds)) prevWidgetIds = [];
+
+    // Decided before any mutation: `mutator` runs once per config representation
+    // and clears savedPositions as it goes, so reading the flag inside it would
+    // be true on the first pass and false on the second.
+    var deregister = {};
+    for (var d = 0; d < prevWidgetIds.length; d++) {
+        var did = prevWidgetIds[d];
+        if (did && savedPositions[did] && savedPositions[did].registeredInPlugins) {
+            deregister[did] = true;
+        }
+    }
 
     var defaultRegions = {
         "omarchy.menu": "left",
@@ -122,6 +166,13 @@ function switchDockWidgetInBar(shell, newWidgetId, prevWidgetIds, savedPositions
             }
 
             targetList.splice(insertAt, 0, targetEntry);
+
+            // Back on the bar it is found again, so our `plugins` entry is redundant.
+            if (deregister[prevId]) {
+                var stalePluginIdx = findPluginEntryIndex(config, prevId);
+                if (stalePluginIdx !== -1) config.plugins.splice(stalePluginIdx, 1);
+            }
+
             delete savedPositions[prevId];
         }
 
@@ -148,6 +199,14 @@ function switchDockWidgetInBar(shell, newWidgetId, prevWidgetIds, savedPositions
                         list2.splice(i2, 1);
                     }
                 }
+            }
+
+            // Keep it enabled now that it is no longer in the bar layout.
+            if (!isFirstPartyWidget(shell, newWidgetId) && findPluginEntryIndex(config, newWidgetId) === -1) {
+                if (!Array.isArray(config.plugins)) config.plugins = [];
+                config.plugins.push({ id: newWidgetId });
+                if (!savedPositions[newWidgetId]) savedPositions[newWidgetId] = {};
+                savedPositions[newWidgetId].registeredInPlugins = true;
             }
         }
     };


### PR DESCRIPTION
Fixes the main problem in #24: moving a **third-party** widget into the dock disables the plugin, so the slot you just created is dead — and since its bar entry is gone too, the plugin is left with no way in at all.

## Why it happens

`switchDockWidgetInBar()` removes the id from `shell.json`'s `bar.layout`, which is right for the bar. But Omarchy resolves *"is this plugin enabled"* from the same file:

```qml
// omarchy/shell/services/PluginRegistry.qml
function isEnabled(id) {
  ...
  if (manifest.__isFirstParty) return true      // enabled wherever it sits
  return findEntryLocation(config, key).found   // must be FOUND
}
// findEntryLocation searches: config.bar.id | config.bar.layout.* | config.plugins[]
```

First-party widgets short-circuit, which is why this never shows up with the built-ins. A third-party plugin has to be *found*, and after the move it is in none of the three places — no Loader, and `shell.summon()` refuses:

```
WARN qml: summon: plugin not enabled, not summoning: <id>
```

## The change

Register such a widget under the top-level **`plugins`** array when it leaves the bar — where overlay-only plugins already live. Enabled, no bar icon.

- Only for non-first-party widgets, so a built-in never gains a redundant `plugins` entry. If the registry is unreachable it registers anyway: a redundant entry never disables anything, a missing one does.
- The registration is undone when the widget goes back to the bar, **but only if we added it** — a plugin the user already had under `plugins` is left alone.
- The deregistration flag is read *before* the mutator runs. `mutator` is applied once per config representation (`mutateShellConfig` and the config file) and clears `savedPositions` as it goes, so reading the flag inside would be true on the first pass and false on the second.

One file, additive, no change to existing behaviour for first-party widgets.

## Testing

`DockWidgets.js` is a `.pragma library`, so the functions run directly in node. Exercised against a config shaped like a real `shell.json` (third-party widgets in `bar.layout.left`, an existing `plugins: [{id:"mirador"}]`):

| Scenario | Result |
|---|---|
| Third-party widget bar → dock | removed from bar, added to `plugins`, flag recorded |
| Same widget dock → bar | restored to its **original index**, `plugins` back to its original contents |
| Plugin already under `plugins` (overlay-only) → dock → bar | no duplicate entry, flag not set, the user's own entry kept |
| First-party widget (`omarchy.clock`) → dock | `plugins` untouched |
| Swap one third-party dock widget for another | only the new one registered, the old one returned to the bar |

The existing suite still passes (`tests/test_dock_minimize.py`, 12/12).

The end state this produces is also what I'm running: hand-adding the `plugins` entry is what made an app-launcher overlay work from a dock button here, across shell restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
