### PR TITLE
Make the 4.0.3 config-write path observable

### DIFF
--- a/DockWidgets.js
+++ b/DockWidgets.js
@@ -192,7 +192,10 @@ function switchDockWidgetInBar(shell, newWidgetId, prevWidgetIds, savedPositions
     };
 
     if (shell && typeof shell.mutateShellConfig === "function") {
-        shell.mutateShellConfig(mutator);
+        // Omarchy 4.0.3 answers false for third-party plugins and skips the
+        // write; the file branch below is what persists on a scoped host.
+        if (shell.mutateShellConfig(mutator) === false)
+            console.warn("dock: shell declined the config write, editing shell.json directly");
     }
     if (shellConfigFile && typeof shellConfigFile.text === "function" && typeof shellConfigFile.setText === "function") {
         try {
@@ -202,7 +205,9 @@ function switchDockWidgetInBar(shell, newWidgetId, prevWidgetIds, savedPositions
                 mutator(config);
                 shellConfigFile.setText(JSON.stringify(config, null, 2) + "\n");
             }
-        } catch(e) {}
+        } catch(e) {
+            console.warn("dock: could not write shell.json directly:", e);
+        }
     }
 
     return savedPositions;
@@ -269,7 +274,10 @@ function removeWidgetFromBar(shell, widgetId, savedPositions, shellConfigFile) {
     };
 
     if (shell && typeof shell.mutateShellConfig === "function") {
-        shell.mutateShellConfig(mutator);
+        // Omarchy 4.0.3 answers false for third-party plugins and skips the
+        // write; the file branch below is what persists on a scoped host.
+        if (shell.mutateShellConfig(mutator) === false)
+            console.warn("dock: shell declined the config write, editing shell.json directly");
     }
     if (shellConfigFile && typeof shellConfigFile.text === "function" && typeof shellConfigFile.setText === "function") {
         try {
@@ -279,7 +287,9 @@ function removeWidgetFromBar(shell, widgetId, savedPositions, shellConfigFile) {
                 mutator(config);
                 shellConfigFile.setText(JSON.stringify(config, null, 2) + "\n");
             }
-        } catch(e) {}
+        } catch(e) {
+            console.warn("dock: could not write shell.json directly:", e);
+        }
     }
     return savedPositions;
 }
@@ -463,7 +473,10 @@ function returnWidgetToBar(shell, widgetId, savedPositions, defaultRegion, shell
     };
 
     if (shell && typeof shell.mutateShellConfig === "function") {
-        shell.mutateShellConfig(mutator);
+        // Omarchy 4.0.3 answers false for third-party plugins and skips the
+        // write; the file branch below is what persists on a scoped host.
+        if (shell.mutateShellConfig(mutator) === false)
+            console.warn("dock: shell declined the config write, editing shell.json directly");
     }
     if (shellConfigFile && typeof shellConfigFile.text === "function" && typeof shellConfigFile.setText === "function") {
         try {
@@ -473,7 +486,9 @@ function returnWidgetToBar(shell, widgetId, savedPositions, defaultRegion, shell
                 mutator(config);
                 shellConfigFile.setText(JSON.stringify(config, null, 2) + "\n");
             }
-        } catch(e) {}
+        } catch(e) {
+            console.warn("dock: could not write shell.json directly:", e);
+        }
     }
 
     delete savedPositions[widgetId];

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "rosakodu.dock",
   "name": "Dock",
-  "version": "1.8.17",
+  "version": "1.8.18",
   "author": "rosakodu",
   "license": "MIT",
   "description": "Native animated application dock for Omarchy Quattro with dynamic positioning, Hyprland window tracking, Drag & Drop, and seamless Omarchy theme integration.",


### PR DESCRIPTION
## Omarchy 4.0.3: say which config-write path actually ran

Omarchy 4.0.3 capability-scopes third-party plugin shell access. `mutateShellConfig` is gated to kind `"bar"` plugins and answers `false` for this one — so the primary write in `switchDockWidgetInBar` / `removeWidgetFromBar` / `returnWidgetToBar` silently no-ops, and persistence survives only through the `shell.json` file branch below it.

That file branch is genuinely the right path here — not just a workaround. `updateEntryInline` (the seam a scoped host permits for a plugin's own entry) can only rewrite one existing entry's settings, while these mutators add/remove bar layout entries *and* touch `plugins[]`; even a capability-granted `mutateShellConfig` would scope the copy to `bar` only and drop the `plugins[]` mutation. So no behavior change is proposed — the patch makes the dual path explicit and observable:

- log a warning when the shell declines the write (`mutateShellConfig() === false` on a scoped host; pre-4.0.3 shells return `undefined` and stay silent, so no new noise)
- warn on the currently-swallowed `catch(e) {}` in the file branch, so a failed direct write is no longer indistinguishable from success

The file branch already re-reads fresh before each write, preserves `version` and all other keys by round-tripping the parsed file, and the shell's own `FileView` watcher hot-applies the change.

### Testing

- On Omarchy 4.0.3-1: swap a dock widget into the bar → warning logged once, the swap persists across `omarchy restart shell`, and `~/.config/omarchy/shell.json` shows the layout entry moved with `plugins[]` updated
- On a pre-4.0.3 host: no new warnings, behavior unchanged