### PR TITLE
fix(barwidget): open settings card beneath the widget instead of centering on the bar

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -290,13 +290,16 @@ BarWidget {
     }
   }
 
-  // Standard Omarchy KeyboardPanel (Exact same screen level, gap, and animation as Weather & Audio)
+  // Standard Omarchy KeyboardPanel (Exact same screen level, gap, and animation as Weather & Audio),
+  // anchored under this widget's own button rather than centered on the bar.
   KeyboardPanel {
     id: settingsWindow
     anchorItem: button
     owner: root
     bar: root.bar
-    centerOnBar: true
+    // Anchor to the widget itself (left/center/right section) instead of the bar's
+    // midpoint; KeyboardPanel still clamps the card on-screen via its margin.
+    centerOnBar: false
     contentWidth: (Style && typeof Style.space === "function") ? Style.space(410) : 410
     contentHeight: settingsWindow.fittedContentHeight(cardColumn.implicitHeight + 6)
     borderSpec: Border.localOrSurfaceSpec("popups", "border", Color.accent, Color.accent, Math.max(1, Style.space(2)))

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A modern, highly polished, and fully native application dock plugin for **Omarch
 - ⏱️ **Flexible Visibility** — Keep the dock visible, reveal it from the screen edge, or toggle it through a Hyprland keybinding.
 - 🪟 **Native Overlay Mode** — Float the dock above full-screen/tiling windows without shifting Hyprland window arrangements (macOS / Dash to Dock behavior).
 - 🔔 **Real-Time Notification Badges** — Dynamic unread badges on app icons aggregated from D-Bus notifications, Hyprland dwell timers, and window titles.
-- 🎛️ **Status Bar Settings Widget (`BarWidget`)** — Native top bar menu for dock visibility, workspace targeting, Overlay Mode, folder titles, notification badges, and dock widgets.
+- 🎛️ **Status Bar Settings Widget (`BarWidget`)** — Native top bar menu for dock visibility, workspace targeting, Overlay Mode, folder titles, notification badges, and dock widgets; the settings card opens directly beneath the widget wherever it's placed in the bar (left, center, or right).
 - 🎨 **100% Native Theme Sync** — Clean borderless status capsules that automatically react to Omarchy colors (`Color.accent`, `Color.bar.background`), system fonts, and window corner radius tokens.
 - 🔤 **Subpixel Vector Glyphs (`DockGlyph`)** — GPU-accelerated vector curve rendering without font hinting distortion or pixel jitter during animations.
 


### PR DESCRIPTION
## Problem

The `···` settings card is a `KeyboardPanel` with `centerOnBar: true`, so it always opens centered on the bar regardless of whether the user placed the widget in the bar's left, center, or right section.

## Fix

Set `centerOnBar: false`. `KeyboardPanel` then positions the card under the widget's own button (or beside it for vertical bars) and already clamps it on-screen via its margin. This matches how the other first-party bar widgets anchor their popups.

## Testing

Verified on Omarchy 4.0.3 with the widget in the right section on a two-monitor setup.