### PR TITLE
fix(reveal): slide the dock in only on the monitor that triggered the reveal

### DIFF
--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -354,6 +354,11 @@ Item {
     property int visibilityOverride: DockSettings.VISIBILITY_OVERRIDE_FOLLOW
     property string keyboardTargetWorkspace: ""
     property string keyboardTargetMonitorName: ""
+    // Which screen triggered the current reveal (edge-hover screen, or the
+    // focused screen for a keyboard toggle). "" means no specific trigger is
+    // recorded, in which case screenRevealTarget() falls back to the focused
+    // monitor.
+    property string revealMonitorName: ""
     property string baseDockMonitorName: ""
     property bool widgetPickerRevealOwned: false
     property int widgetPickerPreviousVisibilityOverride: DockSettings.VISIBILITY_OVERRIDE_FOLLOW
@@ -667,6 +672,24 @@ Item {
         root.isWorkspaceEmpty
     )
 
+    // The screen whose dock should slide in for the current reveal, or "" if
+    // every screen's dock should (always mode, or an explicit visibleWorkspace
+    // selector).
+    readonly property string revealTargetMonitorName: DockSettings.screenRevealTarget(
+        root.visibilityMode,
+        root.visibleWorkspace,
+        root.revealMonitorName,
+        Hyprland.focusedMonitor ? String(Hyprland.focusedMonitor.name || "") : ""
+    )
+
+    function screenSlidesOut(screen) {
+        return DockSettings.screenSlidesOut(
+            root.shouldSlideOut,
+            root.revealTargetMonitorName,
+            screen ? screen.name : ""
+        )
+    }
+
     function closeDockPopups() {
         root.closePopups()
     }
@@ -692,6 +715,7 @@ Item {
             return "hidden"
         } else {
             autohideLeaveTimer.stop()
+            root.revealMonitorName = Hyprland.focusedMonitor ? String(Hyprland.focusedMonitor.name || "") : ""
             root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_SHOWN
             root.isDockHovered = true
             return "shown"
@@ -717,6 +741,7 @@ Item {
     onDockRevealedChanged: {
         if (!dockRevealed) {
             root.closeDockPopups()
+            root.revealMonitorName = ""
         }
     }
 
@@ -725,6 +750,7 @@ Item {
         root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_FOLLOW
         root.keyboardTargetWorkspace = ""
         root.keyboardTargetMonitorName = ""
+        root.revealMonitorName = ""
         root.isDockHovered = false
         autohideLeaveTimer.stop()
     }
@@ -740,6 +766,7 @@ Item {
         root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_FOLLOW
         root.keyboardTargetWorkspace = ""
         root.keyboardTargetMonitorName = ""
+        root.revealMonitorName = ""
     }
 
     property var lastRemapScreen: null
@@ -2528,6 +2555,17 @@ Item {
     readonly property var dockWindow: {
         var instances = dockVariants.instances
         var count = instances ? instances.length : 0
+        // When a reveal is targeting a specific (possibly non-focused) screen,
+        // popups should attach to that revealed instance instead of whichever
+        // screen has keyboard focus.
+        var targetName = root.revealTargetMonitorName !== "" ? root.revealTargetMonitorName : ""
+        if (targetName !== "") {
+            for (var t = 0; t < count; t++) {
+                var targetWin = instances[t]
+                if (targetWin && targetWin.screen && String(targetWin.screen.name || "") === targetName)
+                    return targetWin
+            }
+        }
         var focusedName = Hyprland.focusedMonitor ? String(Hyprland.focusedMonitor.name || "") : ""
         for (var i = 0; i < count; i++) {
             var win = instances[i]
@@ -2548,6 +2586,11 @@ Item {
                 required property var modelData
                 property alias surface: dockSurface
                 property alias hoverHandler: dockHoverHandler
+                // Per-screen slide state: this screen's own reveal state,
+                // unless another screen is the current reveal target (in
+                // which case this one stays/goes slid out even while
+                // root.shouldSlideOut is false).
+                readonly property bool slidOut: root.screenSlidesOut(modelData)
                 screen: modelData
                 visible: root.dockMapped && root.screenShowsDock(modelData) && !remapGuard.remapping
 
@@ -2564,7 +2607,7 @@ Item {
                 // lets fullscreen content win.
                 WlrLayershell.layer: root.autohide ? WlrLayer.Overlay : WlrLayer.Top
                 WlrLayershell.keyboardFocus: root.isEditMode ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
-                exclusionMode: root.dockRevealed && !root.overlayMode ? ExclusionMode.Auto : ExclusionMode.Ignore
+                exclusionMode: root.dockRevealed && !dockLayer.slidOut && !root.overlayMode ? ExclusionMode.Auto : ExclusionMode.Ignore
                 color: "transparent"
                 surfaceFormat.opaque: false
 
@@ -2576,8 +2619,8 @@ Item {
                 // -- for a dock that cannot be hovered anyway. Revealing it is
                 // the separate edge trigger's job. Hand the strip back.
                 mask: Region {
-                    width: root.shouldSlideOut ? 0 : dockLayer.width
-                    height: root.shouldSlideOut ? 0 : dockLayer.height
+                    width: dockLayer.slidOut ? 0 : dockLayer.width
+                    height: dockLayer.slidOut ? 0 : dockLayer.height
                 }
 
                 anchors {
@@ -2599,7 +2642,7 @@ Item {
 
                 HoverHandler {
                     id: dockHoverHandler
-                    enabled: root.autohide && !root.shouldSlideOut
+                    enabled: root.autohide && !dockLayer.slidOut
                     onHoveredChanged: {
                         root.evaluateHoverState()
                     }
@@ -2668,13 +2711,13 @@ Item {
             transform: Translate {
                 id: autohideTranslate
                 x: {
-                    if (!root.shouldSlideOut) return 0
+                    if (!dockLayer.slidOut) return 0
                     if (root.barPosition === "right") return -56
                     if (root.barPosition === "left") return 56
                     return 0
                 }
                 y: {
-                    if (!root.shouldSlideOut) return 0
+                    if (!dockLayer.slidOut) return 0
                     if (root.barPosition === "top") return 56
                     if (root.barPosition === "bottom") return -56
                     return 0
@@ -3259,7 +3302,7 @@ Item {
                 screen: modelData
                 visible: root.dockAvailable
                          && (root.visibilityMode === "hover" || root.visibilityMode === "hybrid")
-                         && root.shouldSlideOut
+                         && root.screenSlidesOut(modelData)
                          && root.screenShowsDock(modelData)
 
                 WlrLayershell.namespace: "omarchy-dock-edge"
@@ -3304,6 +3347,7 @@ Item {
                                 if (root.visibilityOverride === DockSettings.VISIBILITY_OVERRIDE_HIDDEN) {
                                     root.visibilityOverride = DockSettings.VISIBILITY_OVERRIDE_FOLLOW
                                 }
+                                root.revealMonitorName = edgeTriggerWindow.modelData ? String(edgeTriggerWindow.modelData.name || "") : ""
                                 root.isDockHovered = true
                                 autohideLeaveTimer.restart()
                             }

--- a/DockSettings.js
+++ b/DockSettings.js
@@ -107,6 +107,27 @@ function releaseInteractionVisibilityOverride(owned, previousOverride, currentOv
         : normalizeVisibilityOverride(currentOverride)
 }
 
+// Which screen's dock should slide in on a reveal. Returns "" to mean "every
+// screen" (always mode, or an explicit visibleWorkspace selector, both of
+// which are already single- or all-screen by construction). Otherwise the
+// screen that triggered the reveal wins, falling back to the focused screen
+// for reveals with no specific trigger (e.g. the keyboard toggle finding no
+// focused monitor, or the empty-workspace auto-reveal).
+function screenRevealTarget(visibilityMode, visibleWorkspace, revealMonitorName, focusedMonitorName) {
+    var mode = normalizeVisibilityMode(visibilityMode, false)
+    if (mode === VISIBILITY_ALWAYS) return ""
+    if (normalizeVisibleWorkspace(visibleWorkspace) !== "all") return ""
+    if (revealMonitorName) return String(revealMonitorName)
+    if (focusedMonitorName) return String(focusedMonitorName)
+    return ""
+}
+
+// Per-screen slide-out state: slid out globally, or slid out because another
+// screen is the current reveal target.
+function screenSlidesOut(globalShouldSlideOut, target, screenName) {
+    return globalShouldSlideOut === true || (target !== "" && String(screenName) !== target)
+}
+
 function dockScreenTarget(visibleWorkspace, visibilityMode, visibilityOverride) {
     if (normalizeVisibleWorkspace(visibleWorkspace) !== "all") return "configured"
     return "all"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A modern, highly polished, and fully native application dock plugin for **Omarch
 - 🌐 **Full Web Apps (PWA) Support** — Automatic domain matching for Chrome/Chromium web apps (Google Maps, Google Contacts, WhatsApp, YouTube, Discord, etc.) with native GTK theme icons.
 - ⚡ **Zero-Flicker Boot & Tile Lift** — Two-phase initialization instantly reserves Hyprland exclusive space to lift tiled windows smoothly, followed by a monolithic fade-in once all vector theme icons are loaded.
 - 🧭 **Dynamic Auto-Positioning** — Automatically adapts its position opposite to the Omarchy status bar (top $\leftrightarrow$ bottom, left $\leftrightarrow$ right) and draws a dock on every connected monitor.
-- ⏱️ **Flexible Visibility** — Keep the dock visible, reveal it from the screen edge, or toggle it through a Hyprland keybinding.
+- ⏱️ **Flexible Visibility** — Keep the dock visible, reveal it from the screen edge, or toggle it through a Hyprland keybinding. On multi-monitor setups with an autohide mode, a reveal only slides the dock in on the monitor that triggered it; the others stay hidden with their edge triggers still armed.
 - 🪟 **Native Overlay Mode** — Float the dock above full-screen/tiling windows without shifting Hyprland window arrangements (macOS / Dash to Dock behavior).
 - 🔔 **Real-Time Notification Badges** — Dynamic unread badges on app icons aggregated from D-Bus notifications, Hyprland dwell timers, and window titles.
 - 🎛️ **Status Bar Settings Widget (`BarWidget`)** — Native top bar menu for dock visibility, workspace targeting, Overlay Mode, folder titles, notification badges, and dock widgets.
@@ -106,7 +106,11 @@ trigger and keyboard shortcuts operate concurrently. If the dock is already visi
 press closes it without moving it and the next press opens it on the current
 target. In `keybind` and `hybrid` modes, summoned docks automatically hide after
 the same 1.5-second inactivity delay used by hover mode. Keeping the pointer or
-a dock popup active pauses the dismissal timer.
+a dock popup active pauses the dismissal timer. With `visibleWorkspace` set to
+`all` on a multi-monitor setup, the keyboard shortcut reveals the dock only on
+the currently focused monitor, and hovering a screen edge reveals only that
+screen's dock — the other monitors' docks stay slid out until their own edge
+is hovered or the shortcut is used while they are focused.
 
 Pinned items and folder layouts are automatically saved to `~/.config/omarchy/dock-pinned.json`.
 

--- a/tests/tst_DockSettings.qml
+++ b/tests/tst_DockSettings.qml
@@ -200,6 +200,35 @@ TestCase {
         compare(DockSettings.screenShowsDock(data.target, data.screen, data.configured, data.captured, data.focused), data.expected)
     }
 
+    function test_screenRevealTarget_data() {
+        return [
+            { tag: "always-ignores-reveal", mode: "always", workspace: "all", reveal: "DP-1", focused: "DP-2", expected: "" },
+            { tag: "explicit-workspace-ignores-reveal", mode: "hover", workspace: "7", reveal: "DP-1", focused: "DP-2", expected: "" },
+            { tag: "hover-uses-reveal-monitor", mode: "hover", workspace: "all", reveal: "DP-1", focused: "DP-2", expected: "DP-1" },
+            { tag: "hover-falls-back-to-focused", mode: "hover", workspace: "all", reveal: "", focused: "DP-2", expected: "DP-2" },
+            { tag: "hybrid-uses-reveal-monitor", mode: "hybrid", workspace: "all", reveal: "eDP-1", focused: "DP-2", expected: "eDP-1" },
+            { tag: "keybind-falls-back-to-focused", mode: "keybind", workspace: "all", reveal: "", focused: "DP-2", expected: "DP-2" },
+            { tag: "no-reveal-no-focus", mode: "hover", workspace: "all", reveal: "", focused: "", expected: "" }
+        ]
+    }
+
+    function test_screenRevealTarget(data) {
+        compare(DockSettings.screenRevealTarget(data.mode, data.workspace, data.reveal, data.focused), data.expected)
+    }
+
+    function test_screenSlidesOut_data() {
+        return [
+            { tag: "global-slide-out-wins", globalSlide: true, target: "DP-1", screen: "DP-1", expected: true },
+            { tag: "no-target-means-all-screens-follow-global", globalSlide: false, target: "", screen: "DP-1", expected: false },
+            { tag: "target-matches-screen-stays-in", globalSlide: false, target: "DP-1", screen: "DP-1", expected: false },
+            { tag: "target-is-other-screen-slides-out", globalSlide: false, target: "DP-1", screen: "DP-2", expected: true }
+        ]
+    }
+
+    function test_screenSlidesOut(data) {
+        compare(DockSettings.screenSlidesOut(data.globalSlide, data.target, data.screen), data.expected)
+    }
+
     function test_visibleDockClosesWithoutRetargeting() {
         var focusedWorkspace = { id: 2, name: "2", active: true }
         var decision = DockSettings.keyboardToggleDecision(true, "all", focusedWorkspace, null)


### PR DESCRIPTION
## Problem

With `visibleWorkspace: "all"` and an autohide mode (`hover`, `keybind`, `hybrid`), the reveal state is a single global flag on the service root. Hovering the screen edge on one monitor therefore slides the dock in on every monitor at once, and the keyboard toggle does the same.

## Fix

- Record which monitor triggered the reveal (`revealMonitorName`): the edge trigger's screen for hover, the focused monitor for the keyboard toggle.
- Add pure helpers `screenRevealTarget()` and `screenSlidesOut()` in `DockSettings.js` that derive a per-screen slide state from the global one.
- Each dock window uses its own `slidOut` for the input mask, hover handler, exclusion zone, and slide translation. Windows on other monitors stay mapped and slid out, so their edge triggers remain armed and hovering another edge simply moves the reveal.
- `dockWindow` prefers the revealed instance so folder and widget popups attach to the dock that is actually visible.

`always` mode and explicit workspace selectors are unchanged. The empty-workspace auto-reveal in hover mode targets the focused monitor, matching what `getActiveWorkspaceWindowCount()` inspects.

## Testing

- 11 new data-driven tests in `tests/tst_DockSettings.qml` (74 total, all passing).
- Verified live on a two-monitor Hyprland setup: a keyboard reveal with the left monitor focused showed the dock on the left only, confirmed by screenshots of both outputs.