### PR TITLE
feat(size): add configurable iconSize setting with bar widget presets

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -19,6 +19,7 @@ BarWidget {
   readonly property bool autohide: root.visibilityMode !== "always"
   property bool overlayMode: false
   property string visibleWorkspace: "all"
+  property int iconSize: DockSettings.DEFAULT_ICON_SIZE
   property bool showFolderTitles: true
   property bool showBadges: true
   property bool widgetsEnabled: true
@@ -72,6 +73,7 @@ BarWidget {
         }
         root.overlayMode = normalized.overlayMode
         root.visibleWorkspace = normalized.visibleWorkspace
+        root.iconSize = normalized.iconSize
         if (s && s.dockEnabled !== undefined) {
           root.dockEnabled = (s.dockEnabled === true || s.dockEnabled === "true" || s.dockEnabled === 1 || s.dockEnabled === "1")
         } else {
@@ -119,6 +121,7 @@ BarWidget {
     s.autohide = DockSettings.legacyAutohide(root.visibilityMode)
     s.overlayMode = root.overlayMode
     s.visibleWorkspace = root.visibleWorkspace
+    s.iconSize = root.iconSize
     s.showFolderTitles = root.showFolderTitles
     s.showBadges = root.showBadges
     s.widgetsEnabled = root.widgetsEnabled
@@ -204,6 +207,36 @@ BarWidget {
     if (root.bar && typeof root.bar.run === "function") {
       root.bar.run("omarchy-shell rosakodu.dock setVisibleWorkspace " + root.visibleWorkspace)
     }
+  }
+
+  function setIconSize(val) {
+    root.iconSize = DockSettings.normalizeIconSize(val)
+    saveSettings()
+    if (root.bar && typeof root.bar.run === "function") {
+      root.bar.run("omarchy-shell rosakodu.dock setIconSize " + root.iconSize)
+    }
+  }
+
+  readonly property var iconSizePresets: [
+    { value: "20", label: "Small" },
+    { value: "24", label: "Medium (default)" },
+    { value: "32", label: "Large" },
+    { value: "40", label: "Extra large" }
+  ]
+
+  function buildIconSizeOptions() {
+    var opts = root.iconSizePresets.slice()
+    var current = String(root.iconSize)
+    var isPreset = opts.some(function(o) { return o.value === current })
+    if (!isPreset) {
+      opts.push({ value: current, label: "Custom (" + root.iconSize + " px)" })
+    }
+    return opts
+  }
+
+  readonly property var iconSizeOptions: {
+    var _sel = root.iconSize
+    return root.buildIconSizeOptions()
   }
 
   function buildWorkspaceOptions() {
@@ -429,7 +462,17 @@ BarWidget {
           onChanged: function(value) { root.setVisibleWorkspace(value) }
         }
 
-        // 3. Autohide dock (edge hover)
+        // 3. Dock Size Dropdown
+        DockDropdown {
+          Layout.fillWidth: true
+          showLabel: true
+          label: "Dock size"
+          value: String(root.iconSize)
+          options: root.iconSizeOptions
+          onChanged: function(value) { root.setIconSize(value) }
+        }
+
+        // 4. Autohide dock (edge hover)
         Rectangle {
           id: autohideRow
           Layout.fillWidth: true
@@ -510,7 +553,7 @@ BarWidget {
           }
         }
 
-        // 4. Keyboard shortcut toggle
+        // 5. Keyboard shortcut toggle
         Rectangle {
           id: keybindRow
           Layout.fillWidth: true
@@ -591,7 +634,7 @@ BarWidget {
           }
         }
 
-        // 5. Shortcut Hint (smoothly appears ONLY when Keyboard shortcut is active)
+        // 6. Shortcut Hint (smoothly appears ONLY when Keyboard shortcut is active)
         ColumnLayout {
           id: shortcutHintCard
           Layout.fillWidth: true

--- a/DockItem.qml
+++ b/DockItem.qml
@@ -6,6 +6,7 @@ import Quickshell.Hyprland
 import qs.Commons
 import qs.Ui
 import "DockModel.js" as DockModel
+import "DockSettings.js" as DockSettings
 import "components"
 
 Item {
@@ -235,7 +236,7 @@ Item {
             height: root.iconBaseSize
             text: (root.itemData && root.itemData.icon) ? root.itemData.icon : ""
             fontFamily: Style.font.family
-            fontSize: 20
+            fontSize: Math.round(20 * root.iconBaseSize / DockSettings.DEFAULT_ICON_SIZE)
             color: Color.accent
         }
 

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -59,8 +59,9 @@ Item {
     }
 
     // Static Standard Dock Geometry (Strictly stable, no jumping/twitching on window state)
-    readonly property real slotSize: 42
-    readonly property real iconBaseSize: 24
+    property int iconSize: DockSettings.DEFAULT_ICON_SIZE
+    readonly property real iconBaseSize: root.iconSize
+    readonly property real slotSize: DockSettings.slotSizeForIconSize(root.iconSize)
 
     // Live 1D Rail Displacement for Main Dock Bar
     property int dockDragActiveIndex: -1
@@ -120,6 +121,7 @@ Item {
         function setShowFolderTitles(val: string): string { root.showFolderTitles = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setShowBadges(val: string): string { root.showBadges = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setOverlayMode(val: string): string { root.overlayMode = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
+        function setIconSize(val: string): string { root.setIconSize(val); return "ok" }
         function ping(): string { return "ok" }
     }
 
@@ -897,6 +899,7 @@ Item {
                 }
                 root.overlayMode = normalized.overlayMode
                 root.visibleWorkspace = normalized.visibleWorkspace
+                root.iconSize = normalized.iconSize
                 if (s.dockEnabled !== undefined) {
                     root.dockEnabled = (s.dockEnabled === true || s.dockEnabled === "true" || s.dockEnabled === 1 || s.dockEnabled === "1")
                 } else {
@@ -970,6 +973,7 @@ Item {
             autohide: DockSettings.legacyAutohide(root.visibilityMode),
             overlayMode: root.overlayMode,
             visibleWorkspace: root.visibleWorkspace,
+            iconSize: root.iconSize,
             autohideEdgeDepth: root.autohideEdgeDepth,
             showFolderTitles: root.showFolderTitles,
             showBadges: root.showBadges,
@@ -1015,6 +1019,11 @@ Item {
 
     function setVisibleWorkspace(workspace) {
         root.visibleWorkspace = DockSettings.normalizeVisibleWorkspace(workspace)
+        saveSettings()
+    }
+
+    function setIconSize(val) {
+        root.iconSize = DockSettings.normalizeIconSize(val)
         saveSettings()
     }
 
@@ -2773,7 +2782,7 @@ Item {
                                     return root.getWidgetIcon(modelData, it)
                                 }
                                 fontFamily: (leftWidgetLoader.item && leftWidgetLoader.item.fontFamily) ? leftWidgetLoader.item.fontFamily : ((leftWidgetLoader.item && leftWidgetLoader.item.font && leftWidgetLoader.item.font.family) ? leftWidgetLoader.item.font.family : Style.font.family)
-                                fontSize: 22
+                                fontSize: Math.round(22 * root.iconBaseSize / DockSettings.DEFAULT_ICON_SIZE)
                                 color: leftWidgetSlotMouse.containsMouse ? Color.accent : Color.composed("popups.text", "popups.text-alpha", Color.text, 0.95)
                                 Behavior on color { ColorAnimation { duration: 120 } }
                             }
@@ -3121,7 +3130,7 @@ Item {
                                     return root.getWidgetIcon(modelData, it)
                                 }
                                 fontFamily: (rightWidgetLoader.item && rightWidgetLoader.item.fontFamily) ? rightWidgetLoader.item.fontFamily : ((rightWidgetLoader.item && rightWidgetLoader.item.font && rightWidgetLoader.item.font.family) ? rightWidgetLoader.item.font.family : Style.font.family)
-                                fontSize: 22
+                                fontSize: Math.round(22 * root.iconBaseSize / DockSettings.DEFAULT_ICON_SIZE)
                                 color: rightWidgetSlotMouse.containsMouse ? Color.accent : Color.composed("popups.text", "popups.text-alpha", Color.text, 0.95)
                                 Behavior on color { ColorAnimation { duration: 120 } }
                             }

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -62,6 +62,9 @@ Item {
     property int iconSize: DockSettings.DEFAULT_ICON_SIZE
     readonly property real iconBaseSize: root.iconSize
     readonly property real slotSize: DockSettings.slotSizeForIconSize(root.iconSize)
+    // Distance the card travels when autohidden: the whole layer window plus its
+    // screen-edge gap, so no strip of the dock stays visible at any icon size.
+    readonly property real slideOutDistance: root.slotSize + 8 + (Style.gapsOut || 5)
 
     // Live 1D Rail Displacement for Main Dock Bar
     property int dockDragActiveIndex: -1
@@ -2678,14 +2681,14 @@ Item {
                 id: autohideTranslate
                 x: {
                     if (!root.shouldSlideOut) return 0
-                    if (root.barPosition === "right") return -56
-                    if (root.barPosition === "left") return 56
+                    if (root.barPosition === "right") return -root.slideOutDistance
+                    if (root.barPosition === "left") return root.slideOutDistance
                     return 0
                 }
                 y: {
                     if (!root.shouldSlideOut) return 0
-                    if (root.barPosition === "top") return 56
-                    if (root.barPosition === "bottom") return -56
+                    if (root.barPosition === "top") return root.slideOutDistance
+                    if (root.barPosition === "bottom") return -root.slideOutDistance
                     return 0
                 }
                 Behavior on x { NumberAnimation { duration: 250; easing.type: Easing.OutCubic } }

--- a/DockSettings.js
+++ b/DockSettings.js
@@ -9,6 +9,11 @@ var VISIBILITY_OVERRIDE_HIDDEN = -1
 var VISIBILITY_OVERRIDE_FOLLOW = 0
 var VISIBILITY_OVERRIDE_SHOWN = 1
 
+var DEFAULT_ICON_SIZE = 24
+var MIN_ICON_SIZE = 16
+var MAX_ICON_SIZE = 64
+var ICON_TO_SLOT_RATIO = 1.75
+
 function normalizeVisibilityMode(value, legacyAutohide) {
     var mode = String(value === undefined || value === null ? "" : value).trim().toLowerCase()
     if (mode === VISIBILITY_ALWAYS || mode === VISIBILITY_HOVER || mode === VISIBILITY_KEYBIND || mode === VISIBILITY_HYBRID) {
@@ -40,12 +45,25 @@ function normalizeVisibleWorkspace(value) {
     return workspace === "" || workspace.toLowerCase() === "all" ? "all" : workspace
 }
 
+function normalizeIconSize(value) {
+    var size = parseInt(value, 10)
+    if (isNaN(size)) return DEFAULT_ICON_SIZE
+    if (size < MIN_ICON_SIZE) return MIN_ICON_SIZE
+    if (size > MAX_ICON_SIZE) return MAX_ICON_SIZE
+    return size
+}
+
+function slotSizeForIconSize(iconSize) {
+    return Math.round(normalizeIconSize(iconSize) * ICON_TO_SLOT_RATIO)
+}
+
 function normalize(raw) {
     var settings = raw && typeof raw === "object" ? raw : {}
     return {
         visibilityMode: normalizeVisibilityMode(settings.visibilityMode, settings.autohide),
         overlayMode: normalizeOverlayMode(settings.overlayMode, settings.spaceMode),
-        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace)
+        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace),
+        iconSize: normalizeIconSize(settings.iconSize)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can customize options directly via the `···` status bar widget or in `~/.
   "visibilityMode": "always",
   "overlayMode": false,
   "visibleWorkspace": "all",
+  "iconSize": 24,
   "showFolderTitles": true,
   "showBadges": true,
   "widgetsEnabled": true,
@@ -86,6 +87,11 @@ workspace name. With `all`, a keyboard opening targets the workspace and
 monitor containing the focused window and keeps that target until the dock is
 closed. With an explicit selector, the dock always targets that workspace and
 can open only while the workspace is active on a monitor.
+`iconSize` sets the icon pixel size, clamped between 16 and 64 (default `24`); the
+slot spacing, badges, and other dock geometry scale proportionally with it. The
+`···` status bar widget's "Dock size" dropdown offers Small (20), Medium (24,
+default), Large (32), and Extra large (40) presets, and shows a "Custom" entry
+whenever the stored value doesn't match one of them.
 
 ### Keyboard toggle
 

--- a/tests/tst_DockSettings.qml
+++ b/tests/tst_DockSettings.qml
@@ -10,6 +10,7 @@ TestCase {
         compare(settings.visibilityMode, "always")
         compare(settings.overlayMode, false)
         compare(settings.visibleWorkspace, "all")
+        compare(settings.iconSize, 24)
     }
 
     function test_legacyAutohideMigration_data() {
@@ -239,5 +240,31 @@ TestCase {
 
         compare(decision.action, "workspace-unavailable")
         compare(decision.targetWorkspace, "")
+    }
+
+    function test_normalizeIconSize_data() {
+        return [
+            { tag: "default-undefined", input: undefined, expected: 24 },
+            { tag: "default-null", input: null, expected: 24 },
+            { tag: "clamp-low", input: 4, expected: 16 },
+            { tag: "clamp-high", input: 128, expected: 64 },
+            { tag: "string-numeric", input: "36", expected: 36 },
+            { tag: "garbage", input: "not-a-number", expected: 24 }
+        ]
+    }
+
+    function test_normalizeIconSize(data) {
+        compare(DockSettings.normalizeIconSize(data.input), data.expected)
+    }
+
+    function test_slotSizeForIconSize_data() {
+        return [
+            { tag: "default", input: 24, expected: 42 },
+            { tag: "one-and-a-half", input: 36, expected: 63 }
+        ]
+    }
+
+    function test_slotSizeForIconSize(data) {
+        compare(DockSettings.slotSizeForIconSize(data.input), data.expected)
     }
 }


### PR DESCRIPTION
## Motivation

Dock geometry is hardcoded (`slotSize: 42`, `iconBaseSize: 24`). On HiDPI displays the default is small, and the only way to change it is to edit `DockPanel.qml`.

## Changes

- New persisted `iconSize` setting (pixels, clamped 16–64, default 24). `slotSize` is derived at the existing 1.75 ratio, so all layout code that already reads `slotSize` / `iconBaseSize` scales with it.
- `DockSettings.js`: `normalizeIconSize()`, `slotSizeForIconSize()`, and `iconSize` in `normalize()`.
- `DockPanel.qml`: reads and saves the setting, adds a `setIconSize` IPC command.
- `BarWidget.qml`: a "Dock size" dropdown with Small (20), Medium (24), Large (32), and Extra large (40) presets, plus a "Custom" entry when the stored value isn't a preset.
- Widget glyphs and the folder symbol scale proportionally. Small fixed-size controls (edit-mode badges, clock text) are deliberately left alone.
- The autohide slide-out translation was a fixed 56 px tuned for the default slot; at larger sizes a strip of the card stayed visible at the screen edge. It is now derived from the layer window height plus its edge gap.

## Testing

- 8 new tests in `tests/tst_DockSettings.qml`, all passing.
- Verified live at 24, 32, 36, and 40 px on a 1.6-scale display, including that the dock fully clears the screen edge when hidden.