### PR TITLE
feat(autohide): add configurable autohideDelay setting with bar widget presets

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -19,6 +19,7 @@ BarWidget {
   readonly property bool autohide: root.visibilityMode !== "always"
   property bool overlayMode: false
   property string visibleWorkspace: "all"
+  property int autohideDelay: DockSettings.DEFAULT_AUTOHIDE_DELAY
   property bool showFolderTitles: true
   property bool showBadges: true
   property bool widgetsEnabled: true
@@ -72,6 +73,7 @@ BarWidget {
         }
         root.overlayMode = normalized.overlayMode
         root.visibleWorkspace = normalized.visibleWorkspace
+        root.autohideDelay = normalized.autohideDelay
         if (s && s.dockEnabled !== undefined) {
           root.dockEnabled = (s.dockEnabled === true || s.dockEnabled === "true" || s.dockEnabled === 1 || s.dockEnabled === "1")
         } else {
@@ -119,6 +121,7 @@ BarWidget {
     s.autohide = DockSettings.legacyAutohide(root.visibilityMode)
     s.overlayMode = root.overlayMode
     s.visibleWorkspace = root.visibleWorkspace
+    s.autohideDelay = root.autohideDelay
     s.showFolderTitles = root.showFolderTitles
     s.showBadges = root.showBadges
     s.widgetsEnabled = root.widgetsEnabled
@@ -204,6 +207,38 @@ BarWidget {
     if (root.bar && typeof root.bar.run === "function") {
       root.bar.run("omarchy-shell rosakodu.dock setVisibleWorkspace " + root.visibleWorkspace)
     }
+  }
+
+  function setAutohideDelay(val) {
+    root.autohideDelay = DockSettings.normalizeAutohideDelay(val)
+    saveSettings()
+    if (root.bar && typeof root.bar.run === "function") {
+      root.bar.run("omarchy-shell rosakodu.dock setAutohideDelay " + root.autohideDelay)
+    }
+  }
+
+  readonly property var autohideDelayPresets: [
+    { value: "500", label: "0.5 seconds" },
+    { value: "1000", label: "1 second" },
+    { value: "1500", label: "1.5 seconds (default)" },
+    { value: "2000", label: "2 seconds" },
+    { value: "3000", label: "3 seconds" },
+    { value: "5000", label: "5 seconds" }
+  ]
+
+  function buildAutohideDelayOptions() {
+    var opts = root.autohideDelayPresets.slice()
+    var current = String(root.autohideDelay)
+    var isPreset = opts.some(function(o) { return o.value === current })
+    if (!isPreset) {
+      opts.push({ value: current, label: "Custom (" + root.autohideDelay + " ms)" })
+    }
+    return opts
+  }
+
+  readonly property var autohideDelayOptions: {
+    var _sel = root.autohideDelay
+    return root.buildAutohideDelayOptions()
   }
 
   function buildWorkspaceOptions() {
@@ -510,7 +545,30 @@ BarWidget {
           }
         }
 
-        // 4. Keyboard shortcut toggle
+        // 4. Autohide delay (only meaningful while autohide dismissal applies)
+        ColumnLayout {
+          id: autohideDelayCard
+          Layout.fillWidth: true
+          readonly property bool active: root.dockEnabled && root.visibilityMode !== "always"
+          Layout.preferredHeight: active ? autohideDelayDropdown.implicitHeight : 0
+          Layout.minimumHeight: 0
+          clip: true
+          visible: Layout.preferredHeight > 0
+          spacing: 0
+          Behavior on Layout.preferredHeight { NumberAnimation { duration: 160; easing.type: Easing.OutCubic } }
+
+          DockDropdown {
+            id: autohideDelayDropdown
+            Layout.fillWidth: true
+            showLabel: true
+            label: "Autohide delay"
+            value: String(root.autohideDelay)
+            options: root.autohideDelayOptions
+            onChanged: function(value) { root.setAutohideDelay(value) }
+          }
+        }
+
+        // 5. Keyboard shortcut toggle
         Rectangle {
           id: keybindRow
           Layout.fillWidth: true
@@ -591,7 +649,7 @@ BarWidget {
           }
         }
 
-        // 5. Shortcut Hint (smoothly appears ONLY when Keyboard shortcut is active)
+        // 6. Shortcut Hint (smoothly appears ONLY when Keyboard shortcut is active)
         ColumnLayout {
           id: shortcutHintCard
           Layout.fillWidth: true

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -62,6 +62,9 @@ Item {
     readonly property real slotSize: 42
     readonly property real iconBaseSize: 24
 
+    // Autohide dismissal delay (hover/hybrid pointer-leave and keybind auto-dismiss)
+    property int autohideDelay: DockSettings.DEFAULT_AUTOHIDE_DELAY
+
     // Live 1D Rail Displacement for Main Dock Bar
     property int dockDragActiveIndex: -1
     property int dockDragTargetIndex: -1
@@ -120,6 +123,7 @@ Item {
         function setShowFolderTitles(val: string): string { root.showFolderTitles = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setShowBadges(val: string): string { root.showBadges = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setOverlayMode(val: string): string { root.overlayMode = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
+        function setAutohideDelay(val: string): string { root.setAutohideDelay(val); return "ok" }
         function ping(): string { return "ok" }
     }
 
@@ -594,7 +598,7 @@ Item {
 
     Timer {
         id: autohideLeaveTimer
-        interval: 1500
+        interval: root.autohideDelay
         repeat: false
         onTriggered: {
             if (!root.autohide) return
@@ -897,6 +901,7 @@ Item {
                 }
                 root.overlayMode = normalized.overlayMode
                 root.visibleWorkspace = normalized.visibleWorkspace
+                root.autohideDelay = normalized.autohideDelay
                 if (s.dockEnabled !== undefined) {
                     root.dockEnabled = (s.dockEnabled === true || s.dockEnabled === "true" || s.dockEnabled === 1 || s.dockEnabled === "1")
                 } else {
@@ -970,6 +975,7 @@ Item {
             autohide: DockSettings.legacyAutohide(root.visibilityMode),
             overlayMode: root.overlayMode,
             visibleWorkspace: root.visibleWorkspace,
+            autohideDelay: root.autohideDelay,
             autohideEdgeDepth: root.autohideEdgeDepth,
             showFolderTitles: root.showFolderTitles,
             showBadges: root.showBadges,
@@ -1021,6 +1027,11 @@ Item {
     function setOverlayMode(val) {
         root.overlayMode = (val === true || val === "true")
         root.saveSettings()
+    }
+
+    function setAutohideDelay(val) {
+        root.autohideDelay = DockSettings.normalizeAutohideDelay(val)
+        saveSettings()
     }
 
     function setShowAppMenu(val) {

--- a/DockSettings.js
+++ b/DockSettings.js
@@ -9,6 +9,10 @@ var VISIBILITY_OVERRIDE_HIDDEN = -1
 var VISIBILITY_OVERRIDE_FOLLOW = 0
 var VISIBILITY_OVERRIDE_SHOWN = 1
 
+var DEFAULT_AUTOHIDE_DELAY = 1500
+var MIN_AUTOHIDE_DELAY = 100
+var MAX_AUTOHIDE_DELAY = 10000
+
 function normalizeVisibilityMode(value, legacyAutohide) {
     var mode = String(value === undefined || value === null ? "" : value).trim().toLowerCase()
     if (mode === VISIBILITY_ALWAYS || mode === VISIBILITY_HOVER || mode === VISIBILITY_KEYBIND || mode === VISIBILITY_HYBRID) {
@@ -40,12 +44,21 @@ function normalizeVisibleWorkspace(value) {
     return workspace === "" || workspace.toLowerCase() === "all" ? "all" : workspace
 }
 
+function normalizeAutohideDelay(value) {
+    var delay = parseInt(value, 10)
+    if (isNaN(delay)) return DEFAULT_AUTOHIDE_DELAY
+    if (delay < MIN_AUTOHIDE_DELAY) return MIN_AUTOHIDE_DELAY
+    if (delay > MAX_AUTOHIDE_DELAY) return MAX_AUTOHIDE_DELAY
+    return delay
+}
+
 function normalize(raw) {
     var settings = raw && typeof raw === "object" ? raw : {}
     return {
         visibilityMode: normalizeVisibilityMode(settings.visibilityMode, settings.autohide),
         overlayMode: normalizeOverlayMode(settings.overlayMode, settings.spaceMode),
-        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace)
+        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace),
+        autohideDelay: normalizeAutohideDelay(settings.autohideDelay)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can customize options directly via the `···` status bar widget or in `~/.
   "visibilityMode": "always",
   "overlayMode": false,
   "visibleWorkspace": "all",
+  "autohideDelay": 1500,
   "showFolderTitles": true,
   "showBadges": true,
   "widgetsEnabled": true,
@@ -86,6 +87,12 @@ workspace name. With `all`, a keyboard opening targets the workspace and
 monitor containing the focused window and keeps that target until the dock is
 closed. With an explicit selector, the dock always targets that workspace and
 can open only while the workspace is active on a monitor.
+`autohideDelay` sets, in milliseconds, how long the dock waits after the
+pointer leaves it (hover/hybrid mode) or after a keybind reveal (keybind/hybrid
+mode) before dismissing itself, clamped between 100 and 10000 (default
+`1500`). The `···` status bar widget's "Autohide delay" dropdown offers 0.5,
+1, 1.5 (default), 2, 3, and 5 second presets, and shows a "Custom" entry
+whenever the stored value doesn't match one of them.
 
 ### Keyboard toggle
 
@@ -105,8 +112,9 @@ accepts only the screen-edge trigger. In `hybrid` mode, both the screen-edge hov
 trigger and keyboard shortcuts operate concurrently. If the dock is already visible, the first
 press closes it without moving it and the next press opens it on the current
 target. In `keybind` and `hybrid` modes, summoned docks automatically hide after
-the same 1.5-second inactivity delay used by hover mode. Keeping the pointer or
-a dock popup active pauses the dismissal timer.
+the same configurable inactivity delay used by hover mode (`autohideDelay`,
+default 1.5 seconds). Keeping the pointer or a dock popup active pauses the
+dismissal timer.
 
 Pinned items and folder layouts are automatically saved to `~/.config/omarchy/dock-pinned.json`.
 

--- a/tests/tst_DockSettings.qml
+++ b/tests/tst_DockSettings.qml
@@ -10,6 +10,7 @@ TestCase {
         compare(settings.visibilityMode, "always")
         compare(settings.overlayMode, false)
         compare(settings.visibleWorkspace, "all")
+        compare(settings.autohideDelay, 1500)
     }
 
     function test_legacyAutohideMigration_data() {
@@ -239,5 +240,20 @@ TestCase {
 
         compare(decision.action, "workspace-unavailable")
         compare(decision.targetWorkspace, "")
+    }
+
+    function test_normalizeAutohideDelay_data() {
+        return [
+            { tag: "default-undefined", input: undefined, expected: 1500 },
+            { tag: "default-null", input: null, expected: 1500 },
+            { tag: "clamp-low", input: 10, expected: 100 },
+            { tag: "clamp-high", input: 20000, expected: 10000 },
+            { tag: "string-numeric", input: "2500", expected: 2500 },
+            { tag: "garbage", input: "not-a-number", expected: 1500 }
+        ]
+    }
+
+    function test_normalizeAutohideDelay(data) {
+        compare(DockSettings.normalizeAutohideDelay(data.input), data.expected)
     }
 }


### PR DESCRIPTION
## Motivation

The autohide dismissal delay is a fixed 1500 ms (`autohideLeaveTimer`). Users who want the dock to linger longer, or vanish faster, have no option.

## Changes

- New persisted `autohideDelay` setting (milliseconds, clamped 100–10000, default 1500). It applies to the hover/hybrid pointer-leave dismissal and the keybind/hybrid auto-dismiss, which share the same timer.
- `DockSettings.js`: `normalizeAutohideDelay()` and `autohideDelay` in `normalize()`.
- `DockPanel.qml`: binds the timer interval, reads and saves the setting, adds a `setAutohideDelay` IPC command.
- `BarWidget.qml`: an "Autohide delay" dropdown with 0.5, 1, 1.5, 2, 3, and 5 second presets plus a "Custom" entry. The row collapses when the dock is in `always` mode, using the same technique as the shortcut-hint row.
- README documents the key and the presets.

## Testing

- 6 new tests in `tests/tst_DockSettings.qml`, all passing.
- Verified live via the IPC command and the settings card on Omarchy 4.0.3.