### PR TITLE
feat(autohide): add showOnEmptyWorkspace setting to keep the dock hidden on empty workspaces

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -20,6 +20,7 @@ BarWidget {
   property bool overlayMode: false
   property string visibleWorkspace: "all"
   property bool showFolderTitles: true
+  property bool showOnEmptyWorkspace: true
   property bool showBadges: true
   property bool widgetsEnabled: true
   readonly property bool settingsOpen: settingsWindow.open
@@ -80,6 +81,7 @@ BarWidget {
         if (s && s.showFolderTitles !== undefined) {
           root.showFolderTitles = (s.showFolderTitles === true)
         }
+        root.showOnEmptyWorkspace = normalized.showOnEmptyWorkspace
         if (s && s.showBadges !== undefined) {
           root.showBadges = (s.showBadges === true)
         }
@@ -120,6 +122,7 @@ BarWidget {
     s.overlayMode = root.overlayMode
     s.visibleWorkspace = root.visibleWorkspace
     s.showFolderTitles = root.showFolderTitles
+    s.showOnEmptyWorkspace = root.showOnEmptyWorkspace
     s.showBadges = root.showBadges
     s.widgetsEnabled = root.widgetsEnabled
     s.appMenuPosition = root.appMenuPosition || s.appMenuPosition || "left"
@@ -249,6 +252,14 @@ BarWidget {
     saveSettings()
     if (root.bar && typeof root.bar.run === "function") {
       root.bar.run("omarchy-shell rosakodu.dock setShowFolderTitles " + (val ? "true" : "false"))
+    }
+  }
+
+  function setShowOnEmptyWorkspace(val) {
+    root.showOnEmptyWorkspace = val
+    saveSettings()
+    if (root.bar && typeof root.bar.run === "function") {
+      root.bar.run("omarchy-shell rosakodu.dock setShowOnEmptyWorkspace " + (val ? "true" : "false"))
     }
   }
 
@@ -510,7 +521,92 @@ BarWidget {
           }
         }
 
-        // 4. Keyboard shortcut toggle
+        // 4. Show on empty workspace toggle (collapses unless autohide-on-hover is active)
+        Rectangle {
+          id: showOnEmptyWorkspaceRow
+          Layout.fillWidth: true
+          Layout.preferredHeight: (root.dockEnabled && (root.visibilityMode === "hover" || root.visibilityMode === "hybrid")) ? 42 : 0
+          Layout.minimumHeight: 0
+          clip: true
+          visible: Layout.preferredHeight > 0
+          radius: 8
+          color: toggleEmptyWorkspaceMouse.containsMouse ? Style.hoverFillFor(Color.popups.text, Color.accent) : "transparent"
+          Behavior on color { ColorAnimation { duration: 120 } }
+          Behavior on Layout.preferredHeight { NumberAnimation { duration: 160; easing.type: Easing.OutCubic } }
+
+          readonly property bool active: root.showOnEmptyWorkspace
+
+          RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 10
+            anchors.rightMargin: 10
+            spacing: 8
+
+            ColumnLayout {
+              Layout.fillWidth: true
+              Layout.alignment: Qt.AlignVCenter
+              spacing: 1
+
+              Text {
+                Layout.fillWidth: true
+                text: "Show on empty workspace"
+                textFormat: Text.PlainText
+                font.family: Style.font.family
+                font.pixelSize: 12
+                font.bold: true
+                color: Color.popups.text
+                elide: Text.ElideRight
+              }
+
+              Text {
+                Layout.fillWidth: true
+                text: "Keep the dock visible when the workspace has no windows"
+                textFormat: Text.PlainText
+                font.family: Style.font.family
+                font.pixelSize: 10
+                color: Color.muted
+                elide: Text.ElideRight
+              }
+            }
+
+            Rectangle {
+              id: switchEmptyWorkspaceTrack
+              Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+              Layout.preferredWidth: 36
+              Layout.minimumWidth: 36
+              Layout.maximumWidth: 36
+              Layout.preferredHeight: 20
+              width: 36
+              height: 20
+              radius: 10
+              color: showOnEmptyWorkspaceRow.active ? Color.accent : Qt.rgba(Color.popups.text.r, Color.popups.text.g, Color.popups.text.b, 0.25)
+              Behavior on color { ColorAnimation { duration: 180 } }
+
+              Rectangle {
+                id: switchEmptyWorkspaceThumb
+                width: 14
+                height: 14
+                radius: 7
+                anchors.verticalCenter: parent.verticalCenter
+                x: showOnEmptyWorkspaceRow.active ? (switchEmptyWorkspaceTrack.width - width - 3) : 3
+                color: showOnEmptyWorkspaceRow.active ? Color.background : Color.popups.text
+                Behavior on x { NumberAnimation { duration: 180; easing.type: Easing.OutCubic } }
+              }
+            }
+          }
+
+          MouseArea {
+            id: toggleEmptyWorkspaceMouse
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: {
+              root.setShowOnEmptyWorkspace(!showOnEmptyWorkspaceRow.active)
+            }
+          }
+        }
+
+        // 5. Keyboard shortcut toggle
         Rectangle {
           id: keybindRow
           Layout.fillWidth: true
@@ -591,7 +687,7 @@ BarWidget {
           }
         }
 
-        // 5. Shortcut Hint (smoothly appears ONLY when Keyboard shortcut is active)
+        // 6. Shortcut Hint (smoothly appears ONLY when Keyboard shortcut is active)
         ColumnLayout {
           id: shortcutHintCard
           Layout.fillWidth: true

--- a/DockPanel.qml
+++ b/DockPanel.qml
@@ -120,6 +120,7 @@ Item {
         function setShowFolderTitles(val: string): string { root.showFolderTitles = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setShowBadges(val: string): string { root.showBadges = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
         function setOverlayMode(val: string): string { root.overlayMode = (val === "true" || val === "1"); root.saveSettings(); return "ok" }
+        function setShowOnEmptyWorkspace(val: string): string { root.setShowOnEmptyWorkspace(val === "true" || val === "1"); return "ok" }
         function ping(): string { return "ok" }
     }
 
@@ -361,6 +362,7 @@ Item {
     property int autohideEdgeDepth: 1  // pixels from screen edge that trigger dock reveal
     readonly property int effectiveAutohideEdgeDepth: Math.max(4, Math.min(64, root.autohideEdgeDepth))
     property bool showFolderTitles: true
+    property bool showOnEmptyWorkspace: true
     property bool showBadges: true
     property bool glassmorphism: false
     property real blurOpacity: 0.68
@@ -664,7 +666,7 @@ Item {
         root.visibilityMode,
         root.visibilityOverride,
         root.isDockActive,
-        root.isWorkspaceEmpty
+        root.showOnEmptyWorkspace && root.isWorkspaceEmpty
     )
 
     function closeDockPopups() {
@@ -907,6 +909,7 @@ Item {
                     if (!isNaN(depth) && depth >= 1 && depth <= 64) root.autohideEdgeDepth = depth
                 }
                 root.showFolderTitles = true
+                root.showOnEmptyWorkspace = normalized.showOnEmptyWorkspace
                 if (s.showBadges !== undefined) {
                     root.showBadges = (s.showBadges === true)
                 }
@@ -972,6 +975,7 @@ Item {
             visibleWorkspace: root.visibleWorkspace,
             autohideEdgeDepth: root.autohideEdgeDepth,
             showFolderTitles: root.showFolderTitles,
+            showOnEmptyWorkspace: root.showOnEmptyWorkspace,
             showBadges: root.showBadges,
             glassmorphism: root.glassmorphism,
             blurOpacity: root.blurOpacity,
@@ -986,6 +990,11 @@ Item {
 
     function setDockEnabled(val) {
         root.dockEnabled = (val === true || val === "true" || val === 1 || val === "1")
+        saveSettings()
+    }
+
+    function setShowOnEmptyWorkspace(val) {
+        root.showOnEmptyWorkspace = (val === true || val === "true" || val === 1 || val === "1")
         saveSettings()
     }
 

--- a/DockSettings.js
+++ b/DockSettings.js
@@ -40,12 +40,17 @@ function normalizeVisibleWorkspace(value) {
     return workspace === "" || workspace.toLowerCase() === "all" ? "all" : workspace
 }
 
+function normalizeShowOnEmptyWorkspace(value) {
+    return !(value === false || value === "false" || value === 0 || value === "0")
+}
+
 function normalize(raw) {
     var settings = raw && typeof raw === "object" ? raw : {}
     return {
         visibilityMode: normalizeVisibilityMode(settings.visibilityMode, settings.autohide),
         overlayMode: normalizeOverlayMode(settings.overlayMode, settings.spaceMode),
-        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace)
+        visibleWorkspace: normalizeVisibleWorkspace(settings.visibleWorkspace),
+        showOnEmptyWorkspace: normalizeShowOnEmptyWorkspace(settings.showOnEmptyWorkspace)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can customize options directly via the `···` status bar widget or in `~/.
   "overlayMode": false,
   "visibleWorkspace": "all",
   "showFolderTitles": true,
+  "showOnEmptyWorkspace": true,
   "showBadges": true,
   "widgetsEnabled": true,
   "widgetPosition": "left",
@@ -86,6 +87,10 @@ workspace name. With `all`, a keyboard opening targets the workspace and
 monitor containing the focused window and keeps that target until the dock is
 closed. With an explicit selector, the dock always targets that workspace and
 can open only while the workspace is active on a monitor.
+`showOnEmptyWorkspace` (default `true`) applies in `hover` and `hybrid` modes:
+the dock stays revealed while the active workspace has no windows, regardless
+of pointer position. Set it to `false` to keep the dock hidden until the
+pointer reaches the screen edge, even on an empty workspace.
 
 ### Keyboard toggle
 

--- a/tests/tst_DockSettings.qml
+++ b/tests/tst_DockSettings.qml
@@ -10,6 +10,22 @@ TestCase {
         compare(settings.visibilityMode, "always")
         compare(settings.overlayMode, false)
         compare(settings.visibleWorkspace, "all")
+        compare(settings.showOnEmptyWorkspace, true)
+    }
+
+    function test_normalizeShowOnEmptyWorkspace_data() {
+        return [
+            { tag: "undefined", input: undefined, expected: true },
+            { tag: "true", input: true, expected: true },
+            { tag: "false", input: false, expected: false },
+            { tag: "string-false", input: "false", expected: false },
+            { tag: "zero", input: 0, expected: false },
+            { tag: "string-one", input: "1", expected: true }
+        ]
+    }
+
+    function test_normalizeShowOnEmptyWorkspace(data) {
+        compare(DockSettings.normalizeShowOnEmptyWorkspace(data.input), data.expected)
     }
 
     function test_legacyAutohideMigration_data() {


### PR DESCRIPTION
## Problem

In `hover` and `hybrid` modes, `shouldSlideOut()` keeps the dock revealed whenever the active workspace has no windows. On an empty workspace the dock therefore sits on screen no matter where the pointer is. That is a reasonable default, but some users only ever want the dock to appear when they reach for the screen edge.

## Change

- New persisted boolean `showOnEmptyWorkspace` (default `true`, so existing behaviour is unchanged).
- `DockSettings.js`: `normalizeShowOnEmptyWorkspace()` and the key in `normalize()`. The `shouldSlideOut()` signature is untouched; `DockPanel.qml` passes `showOnEmptyWorkspace && isWorkspaceEmpty` as the `workspaceEmpty` argument.
- `DockPanel.qml`: reads and saves the setting, adds a `setShowOnEmptyWorkspace` IPC command.
- `BarWidget.qml`: a "Show on empty workspace" toggle row in the settings card, collapsed unless the dock is enabled in `hover` or `hybrid` mode.
- README documents the key.

## Testing

- 6 new tests in `tests/tst_DockSettings.qml`, all passing.
- Verified live on Omarchy 4.0.3 with two monitors: with the option off, switching to an empty workspace no longer reveals the dock until the screen edge is hovered. The setting round-trips through the IPC command and dock-settings.json.
